### PR TITLE
Support chain configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist
 node_modules
 coverage
 .DS_Store
+airseeker.json
+secrets.env

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ sensitive information inside secrets.
 
 ### `sponsorWalletMnemonic`
 
-The mnemonic of the wallet used to derive sponsor wallets. Sponsor wallets are derived from dAPI name. It is recommended
-to interpolate this value from secrets. For example:
+The mnemonic of the wallet used to derive sponsor wallets. Sponsor wallets are derived for each dAPI separately. It is
+recommended to interpolate this value from secrets. For example:
 
 ```jsonc
 // The mnemonic is interpolated from the "SPONSOR_WALLET_MNEMONIC" secret.
@@ -33,7 +33,7 @@ A record of chain configurations. The record key is the chain ID. For example:
 
 ```jsonc
 {
-  // Defines a chain with ID 1 (ETH mainnet).
+  // Defines a chain configuration with ID 1 (ETH mainnet).
   "1": {
     "providers": {
       "mainnet": {

--- a/README.md
+++ b/README.md
@@ -7,8 +7,62 @@ simplified and only works with signed APIs.
 
 ## Getting started
 
-To install the dependencies:
+1. `pnpm install` - To install the dependencies.
+2. `cp config/airseeker.example.json config/airseeker.json` - To create the configuration file.
+3. `cp config/secrets.example.env config/secrets.env` - To create the secrets file.
 
-```sh
-pnpm install
+## Configuration
+
+Airseeker needs two configuration files, `airseeker.json` and `secrets.env`. All expressions of a form `${SECRET_NAME}`
+are referring to values from secrets and are interpolated inside the `airseeker.json` at runtime. You are advised to put
+sensitive information inside secrets.
+
+### `sponsorWalletMnemonic`
+
+The mnemonic of the wallet used to derive sponsor wallets. Sponsor wallets are derived from dAPI name. It is recommended
+to interpolate this value from secrets. For example:
+
+```jsonc
+// The mnemonic is interpolated from the "SPONSOR_WALLET_MNEMONIC" secret.
+"sponsorWalletMnemonic": "${SPONSOR_WALLET_MNEMONIC}",
 ```
+
+### `chains`
+
+A record of chain configurations. The record key is the chain ID. For example:
+
+```jsonc
+{
+  // Defines a chain with ID 1 (ETH mainnet).
+  "1": {
+    "providers": {
+      "mainnet": {
+        "url": "http://mainnet.com"
+      }
+    }
+  }
+}
+```
+
+#### `contracts` _(optional)_
+
+A record of contract addresses used by Airseeker. If not specified, the addresses are loaded from
+[Airnode protocol v1](https://github.com/api3dao/airnode-protocol-v1).
+
+##### Api3ServerV1 _(optional)_
+
+The address of the Api3ServerV1 contract. If not specified, the address is loaded from the Airnode protocol v1
+repository.
+
+#### `providers`
+
+A record of providers. The record key is the provider name. Provider name is only used for internal purposes and to
+uniquely identify the provider for the given chain.
+
+##### `providers[<name>]`
+
+A provider configuration.
+
+###### `url`
+
+The URL of the provider.

--- a/README.md
+++ b/README.md
@@ -59,10 +59,41 @@ repository.
 A record of providers. The record key is the provider name. Provider name is only used for internal purposes and to
 uniquely identify the provider for the given chain.
 
-##### `providers[<name>]`
+##### `providers[<NAME>]`
 
 A provider configuration.
 
 ###### `url`
 
 The URL of the provider.
+
+#### `__Temporary__DapiDataRegistry`
+
+The data needed to make the requests to signed API. This data will in the future be stored on-chain in a
+`DapiDataRegistry` contract. For the time being, they are statically defined in the configuration file.
+
+##### `airnodeToSignedApiUrl`
+
+A mapping from Airnode address to signed API URL. When data from particular beacon is needed a request is made to the
+signed API corresponding to the beacon address.
+
+##### `dataFeedIdToBeacons`
+
+A mapping from data feed ID to a list of beacon data.
+
+##### `dataFeedIdToBeacons<DATA_FEED_ID>`
+
+A single element array for a beacon data. If the data feed is a beacon set, the array contains the data for all the
+beacons in the beacon set (in correct order).
+
+###### `dataFeedIdToBeacons<DATA_FEED_ID>[n]`
+
+A beacon data.
+
+`airnode`
+
+The Airnode address of the beacon.
+
+`templateId`
+
+The template ID of the beacon.

--- a/config/airseeker.example.json
+++ b/config/airseeker.example.json
@@ -5,6 +5,20 @@
       "contracts": {
         "Api3ServerV1": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
       },
+      "__Temporary__DapiDataRegistry": {
+        "airnodeToSignedApiUrl": {
+          "0xbF3137b0a7574563a23a8fC8badC6537F98197CC": "http://127.0.0.1:8090/"
+        },
+        "dataFeedIdToBeacons": {
+          "0xebba8507d616ed80766292d200a3598fdba656d9938cecc392765d4a284a69a4": [
+            {
+              "airnode": "0xbF3137b0a7574563a23a8fC8badC6537F98197CC",
+              "templateId": "0xcc35bd1800c06c12856a87311dd95bfcbb3add875844021d59a929d79f3c99bd"
+            }
+          ]
+        },
+        "activeDapiNames": ["ETH/USD"]
+      },
       "providers": {
         "hardhat": {
           "url": "${HARDHAT_PROVIDER_URL}"

--- a/config/airseeker.example.json
+++ b/config/airseeker.example.json
@@ -1,0 +1,15 @@
+{
+  "sponsorWalletMnemonic": "${SPONSOR_WALLET_MNEMONIC}",
+  "chains": {
+    "31337": {
+      "contracts": {
+        "Api3ServerV1": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
+      },
+      "providers": {
+        "hardhat": {
+          "url": "${HARDHAT_PROVIDER_URL}"
+        }
+      }
+    }
+  }
+}

--- a/config/secrets.example.env
+++ b/config/secrets.example.env
@@ -1,0 +1,5 @@
+# Secrets must NOT be quoted.
+#
+# The mnemonic is randomly generated. !!! USE ONLY FOR DEVELOPMENT PURPOSES !!!.
+SPONSOR_WALLET_MNEMONIC=wonder assume clip draw aisle issue angle holiday puzzle glass worry ball
+HARDHAT_PROVIDER_URL=http://127.0.0.1:8545/

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
     "prepare": "husky install",
     "prettier:check": "prettier --check \"./**/*.{js,ts,md,json}\"",
     "prettier:fix": "prettier --write \"./**/*.{js,ts,md,json}\"",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "tsc": "tsc --project ."
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",
+    "@types/lodash": "^4.14.199",
     "@types/node": "^20.8.0",
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",
@@ -35,5 +36,13 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "@api3/airnode-protocol-v1": "^2.10.0",
+    "@api3/promise-utils": "^0.4.0",
+    "dotenv": "^16.3.1",
+    "ethers": "^5.7.2",
+    "lodash": "^4.17.21",
+    "zod": "^3.22.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,33 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+dependencies:
+  '@api3/airnode-protocol-v1':
+    specifier: ^2.10.0
+    version: 2.10.0
+  '@api3/promise-utils':
+    specifier: ^0.4.0
+    version: 0.4.0
+  dotenv:
+    specifier: ^16.3.1
+    version: 16.3.1
+  ethers:
+    specifier: ^5.7.2
+    version: 5.7.2
+  lodash:
+    specifier: ^4.17.21
+    version: 4.17.21
+  zod:
+    specifier: ^3.22.2
+    version: 3.22.2
+
 devDependencies:
   '@types/jest':
     specifier: ^29.5.5
     version: 29.5.5
+  '@types/lodash':
+    specifier: ^4.14.199
+    version: 4.14.199
   '@types/node':
     specifier: ^20.8.0
     version: 20.8.2
@@ -65,6 +88,16 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
     dev: true
+
+  /@api3/airnode-protocol-v1@2.10.0:
+    resolution: {integrity: sha512-5pXI9OUXeyM2IbVYrkW48Eymt7qGT5nfBU8GR2XZsRE8dCRZTIIfp+xdAMH+OFm62GGnUDz9e1uTiAHkRWrtKA==}
+    dependencies:
+      '@openzeppelin/contracts': 4.8.2
+    dev: false
+
+  /@api3/promise-utils@0.4.0:
+    resolution: {integrity: sha512-+8fcNjjQeQAuuSXFwu8PMZcYzjwjDiGYcMUfAQ0lpREb1zHonwWZ2N0B9h/g1cvWzg9YhElbeb/SyhCrNm+b/A==}
+    dev: false
 
   /@babel/code-frame@7.22.13:
     resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
@@ -439,6 +472,321 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@ethersproject/abi@5.7.0:
+    resolution: {integrity: sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==}
+    dependencies:
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
+  /@ethersproject/abstract-provider@5.7.0:
+    resolution: {integrity: sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/networks': 5.7.1
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/web': 5.7.1
+    dev: false
+
+  /@ethersproject/abstract-signer@5.7.0:
+    resolution: {integrity: sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==}
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+    dev: false
+
+  /@ethersproject/address@5.7.0:
+    resolution: {integrity: sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+    dev: false
+
+  /@ethersproject/base64@5.7.0:
+    resolution: {integrity: sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+    dev: false
+
+  /@ethersproject/basex@5.7.0:
+    resolution: {integrity: sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/properties': 5.7.0
+    dev: false
+
+  /@ethersproject/bignumber@5.7.0:
+    resolution: {integrity: sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      bn.js: 5.2.1
+    dev: false
+
+  /@ethersproject/bytes@5.7.0:
+    resolution: {integrity: sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==}
+    dependencies:
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/constants@5.7.0:
+    resolution: {integrity: sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+    dev: false
+
+  /@ethersproject/contracts@5.7.0:
+    resolution: {integrity: sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==}
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+    dev: false
+
+  /@ethersproject/hash@5.7.0:
+    resolution: {integrity: sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==}
+    dependencies:
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/base64': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
+  /@ethersproject/hdnode@5.7.0:
+    resolution: {integrity: sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==}
+    dependencies:
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/basex': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/pbkdf2': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+      '@ethersproject/signing-key': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/wordlists': 5.7.0
+    dev: false
+
+  /@ethersproject/json-wallets@5.7.0:
+    resolution: {integrity: sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==}
+    dependencies:
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/hdnode': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/pbkdf2': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/random': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      aes-js: 3.0.0
+      scrypt-js: 3.0.1
+    dev: false
+
+  /@ethersproject/keccak256@5.7.0:
+    resolution: {integrity: sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      js-sha3: 0.8.0
+    dev: false
+
+  /@ethersproject/logger@5.7.0:
+    resolution: {integrity: sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==}
+    dev: false
+
+  /@ethersproject/networks@5.7.1:
+    resolution: {integrity: sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==}
+    dependencies:
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/pbkdf2@5.7.0:
+    resolution: {integrity: sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+    dev: false
+
+  /@ethersproject/properties@5.7.0:
+    resolution: {integrity: sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==}
+    dependencies:
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/providers@5.7.2:
+    resolution: {integrity: sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==}
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/base64': 5.7.0
+      '@ethersproject/basex': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/networks': 5.7.1
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/random': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/web': 5.7.1
+      bech32: 1.1.4
+      ws: 7.4.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@ethersproject/random@5.7.0:
+    resolution: {integrity: sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/rlp@5.7.0:
+    resolution: {integrity: sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/sha2@5.7.0:
+    resolution: {integrity: sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      hash.js: 1.1.7
+    dev: false
+
+  /@ethersproject/signing-key@5.7.0:
+    resolution: {integrity: sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      bn.js: 5.2.1
+      elliptic: 6.5.4
+      hash.js: 1.1.7
+    dev: false
+
+  /@ethersproject/solidity@5.7.0:
+    resolution: {integrity: sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
+  /@ethersproject/strings@5.7.0:
+    resolution: {integrity: sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/transactions@5.7.0:
+    resolution: {integrity: sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==}
+    dependencies:
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+      '@ethersproject/signing-key': 5.7.0
+    dev: false
+
+  /@ethersproject/units@5.7.0:
+    resolution: {integrity: sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/wallet@5.7.0:
+    resolution: {integrity: sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==}
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/hdnode': 5.7.0
+      '@ethersproject/json-wallets': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/random': 5.7.0
+      '@ethersproject/signing-key': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/wordlists': 5.7.0
+    dev: false
+
+  /@ethersproject/web@5.7.1:
+    resolution: {integrity: sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==}
+    dependencies:
+      '@ethersproject/base64': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
+  /@ethersproject/wordlists@5.7.0:
+    resolution: {integrity: sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
   /@humanwhocodes/config-array@0.11.11:
     resolution: {integrity: sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==}
     engines: {node: '>=10.10.0'}
@@ -759,6 +1107,10 @@ packages:
       fastq: 1.15.0
     dev: true
 
+  /@openzeppelin/contracts@4.8.2:
+    resolution: {integrity: sha512-kEUOgPQszC0fSYWpbh2kT94ltOJwj1qfT2DWo+zVttmGmf97JZ99LspePNaeeaLhCImaHVeBbjaQFZQn7+Zc5g==}
+    dev: false
+
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -862,6 +1214,10 @@ packages:
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/lodash@4.14.199:
+    resolution: {integrity: sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==}
     dev: true
 
   /@types/node@20.8.2:
@@ -1102,6 +1458,10 @@ packages:
     hasBin: true
     dev: true
 
+  /aes-js@3.0.0:
+    resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
+    dev: false
+
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
@@ -1322,10 +1682,22 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
+  /bech32@1.1.4:
+    resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
+    dev: false
+
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
     dev: true
+
+  /bn.js@4.12.0:
+    resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
+    dev: false
+
+  /bn.js@5.2.1:
+    resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
+    dev: false
 
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -1346,6 +1718,10 @@ packages:
     dependencies:
       fill-range: 7.0.1
     dev: true
+
+  /brorand@1.1.0:
+    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
+    dev: false
 
   /browserslist@4.22.1:
     resolution: {integrity: sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==}
@@ -1626,6 +2002,11 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /dotenv@16.3.1:
+    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
+    engines: {node: '>=12'}
+    dev: false
+
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
@@ -1633,6 +2014,18 @@ packages:
   /electron-to-chromium@1.4.539:
     resolution: {integrity: sha512-wRmWJ8F7rgmINuI32S6r2SLrw/h/bJQsDSvBiq9GBfvc2Lh73qTOwn73r3Cf67mjVgFGJYcYtmERzySa5jIWlg==}
     dev: true
+
+  /elliptic@6.5.4:
+    resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
+    dependencies:
+      bn.js: 4.12.0
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+    dev: false
 
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -1948,6 +2341,44 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /ethers@5.7.2:
+    resolution: {integrity: sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==}
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/base64': 5.7.0
+      '@ethersproject/basex': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/hdnode': 5.7.0
+      '@ethersproject/json-wallets': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/networks': 5.7.1
+      '@ethersproject/pbkdf2': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/providers': 5.7.2
+      '@ethersproject/random': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+      '@ethersproject/signing-key': 5.7.0
+      '@ethersproject/solidity': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/units': 5.7.0
+      '@ethersproject/wallet': 5.7.0
+      '@ethersproject/web': 5.7.1
+      '@ethersproject/wordlists': 5.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
 
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -2265,6 +2696,21 @@ packages:
       function-bind: 1.1.1
     dev: true
 
+  /hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+    dev: false
+
+  /hmac-drbg@1.0.1:
+    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+    dev: false
+
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
@@ -2320,7 +2766,6 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /internal-slot@1.0.5:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
@@ -2959,6 +3404,10 @@ packages:
       - ts-node
     dev: true
 
+  /js-sha3@0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
+    dev: false
+
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
     dev: true
@@ -3063,6 +3512,10 @@ packages:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
 
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: false
+
   /lru-cache@10.0.1:
     resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
     engines: {node: 14 || >=16.14}
@@ -3119,6 +3572,14 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
     dev: true
+
+  /minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+    dev: false
+
+  /minimalistic-crypto-utils@1.0.1:
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
+    dev: false
 
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -3516,6 +3977,10 @@ packages:
       get-intrinsic: 1.2.1
       is-regex: 1.1.4
     dev: true
+
+  /scrypt-js@3.0.1:
+    resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
+    dev: false
 
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -4025,6 +4490,19 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
+  /ws@7.4.6:
+    resolution: {integrity: sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -4065,3 +4543,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod@3.22.2:
+    resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
+    dev: false

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,20 @@
+import fs, { readFileSync } from 'fs';
+import { join } from 'path';
+import { go } from '@api3/promise-utils';
+import dotenv from 'dotenv';
+import { configSchema } from './schema';
+import { interpolateSecrets, parseSecrets } from './utils';
+
+export const loadConfig = async () => {
+  const configPath = join(__dirname, '../../config');
+  const rawSecrets = dotenv.parse(readFileSync(join(configPath, 'secrets.env'), 'utf8'));
+
+  const goLoadConfig = await go(async () => {
+    const rawConfig = JSON.parse(fs.readFileSync(join(configPath, 'airseeker.json'), 'utf8'));
+    const secrets = parseSecrets(rawSecrets);
+    return configSchema.parseAsync(interpolateSecrets(rawConfig, secrets));
+  });
+
+  if (!goLoadConfig.success) throw new Error(`Unable to load configuration.`, { cause: goLoadConfig.error });
+  return goLoadConfig.data;
+};

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { ZodError } from 'zod';
+import dotenv from 'dotenv';
+import { chainsSchema, configSchema } from './schema';
+import { interpolateSecrets } from './utils';
+
+it('validates example config', async () => {
+  const exampleConfig = JSON.parse(readFileSync(join(__dirname, '../../config/airseeker.example.json'), 'utf8'));
+
+  // The mnemonic is not interpolated (and thus invalid).
+  await expect(configSchema.parseAsync(exampleConfig)).rejects.toEqual(
+    new ZodError([
+      {
+        validation: 'url',
+        code: 'invalid_string',
+        message: 'Invalid url',
+        path: ['chains', '31337', 'providers', 'hardhat', 'url'],
+      },
+      {
+        code: 'custom',
+        message: 'Invalid mnemonic',
+        path: ['sponsorWalletMnemonic'],
+      },
+    ])
+  );
+
+  const exampleSecrets = dotenv.parse(readFileSync(join(__dirname, '../../config/secrets.example.env'), 'utf8'));
+  await expect(configSchema.parseAsync(interpolateSecrets(exampleConfig, exampleSecrets))).resolves.toEqual(
+    expect.any(Object)
+  );
+});
+
+describe('chains schema', () => {
+  it('uses the specified contract address', () => {
+    const chains = {
+      '31337': {
+        contracts: {
+          Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
+        },
+        providers: {
+          hardhat: {
+            url: 'http://localhost:8545',
+          },
+        },
+      },
+    };
+
+    const parsed = chainsSchema.parse(chains);
+
+    expect(parsed['31337']!.contracts).toEqual({
+      Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
+    });
+  });
+
+  it('uses loads the contract address from airnode-protocol-v1', () => {
+    const chains = {
+      '1': {
+        providers: {
+          mainnet: {
+            url: 'http://mainnet-url.com',
+          },
+        },
+      },
+    };
+
+    const parsed = chainsSchema.parse(chains);
+
+    expect(parsed['1']!.contracts).toEqual({
+      Api3ServerV1: '0x3dEC619dc529363767dEe9E71d8dD1A5bc270D76',
+    });
+  });
+
+  it('throws if the contract address cannot be loaded', () => {
+    const chains = {
+      '31337': {
+        providers: {
+          hardhat: {
+            url: 'http://localhost:8545',
+          },
+        },
+      },
+    };
+
+    expect(() => chainsSchema.parse(chains)).toThrow(
+      new ZodError([
+        {
+          code: 'custom',
+          message: 'Invalid contract addresses',
+          path: ['chains', '31337', 'contracts'],
+        },
+      ])
+    );
+  });
+
+  it('throws if the contract address is invalid', () => {
+    const chains = {
+      '31337': {
+        contracts: {
+          Api3ServerV1: '0xInvalid',
+        },
+        providers: {
+          hardhat: {
+            url: 'http://localhost:8545',
+          },
+        },
+      },
+    };
+
+    expect(() => chainsSchema.parse(chains)).toThrow(
+      new ZodError([
+        {
+          validation: 'regex',
+          code: 'invalid_string',
+          message: 'Must be a valid EVM address',
+          path: ['31337', 'contracts', 'Api3ServerV1'],
+        },
+      ])
+    );
+  });
+});

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -43,6 +43,11 @@ describe('chains schema', () => {
             url: 'http://localhost:8545',
           },
         },
+        __Temporary__DapiDataRegistry: {
+          airnodeToSignedApiUrl: {},
+          dataFeedIdToBeacons: {},
+          activeDapiNames: [],
+        },
       },
     };
 
@@ -61,6 +66,11 @@ describe('chains schema', () => {
             url: 'http://mainnet-url.com',
           },
         },
+        __Temporary__DapiDataRegistry: {
+          airnodeToSignedApiUrl: {},
+          dataFeedIdToBeacons: {},
+          activeDapiNames: [],
+        },
       },
     };
 
@@ -78,6 +88,11 @@ describe('chains schema', () => {
           hardhat: {
             url: 'http://localhost:8545',
           },
+        },
+        __Temporary__DapiDataRegistry: {
+          airnodeToSignedApiUrl: {},
+          dataFeedIdToBeacons: {},
+          activeDapiNames: [],
         },
       },
     };
@@ -103,6 +118,11 @@ describe('chains schema', () => {
           hardhat: {
             url: 'http://localhost:8545',
           },
+        },
+        __Temporary__DapiDataRegistry: {
+          airnodeToSignedApiUrl: {},
+          dataFeedIdToBeacons: {},
+          activeDapiNames: [],
         },
       },
     };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+import { ethers } from 'ethers';
+import { references } from '@api3/airnode-protocol-v1';
+
+export const evmAddressSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Must be a valid EVM address');
+
+export const evmIdSchema = z.string().regex(/^0x[a-fA-F0-9]{64}$/, 'Must be a valid EVM hash');
+
+export const providerSchema = z.object({
+  url: z.string().url(),
+});
+
+export type Provider = z.infer<typeof providerSchema>;
+
+// Contracts are optional. If unspecified, they will be loaded from "airnode-protocol-v1" or error out during
+// validation. We need a chain ID from parent schema to load the contracts.
+export const optionalContractsSchema = z.object({
+  Api3ServerV1: evmAddressSchema.optional(),
+});
+
+// The contracts are guaraneteed to exist after the configuration is passed, but the inferred type would be optional so
+// we create a new schema just to infer the type correctly.
+const contractsSchema = optionalContractsSchema.required();
+
+export type Contracts = z.infer<typeof contractsSchema>;
+
+// Contracts are optional. If unspecified, they will be loaded from "airnode-protocol-v1" or error out during
+// validation. We need a chain ID from parent schema to load the contracts.
+export const optionalChainSchema = z.object({
+  providers: z.record(providerSchema), // The record key is the provider "nickname"
+  contracts: optionalContractsSchema.optional(),
+});
+
+// The contracts are guaraneteed to exist after the configuration is passed, but the inferred type would be optional so
+// we create a new schema just to infer the type correctly.
+const chainSchema = optionalChainSchema.extend({
+  contracts: contractsSchema,
+});
+
+export type Chain = z.infer<typeof chainSchema>;
+
+// Ensure that the contracts are loaded from "airnode-protocol-v1" if not specified.
+export const chainsSchema = z.record(optionalChainSchema).transform((chains, ctx) => {
+  return Object.fromEntries(
+    Object.entries(chains).map(([chainId, chain]) => {
+      const { contracts } = chain;
+      const parsedContracts = contractsSchema.safeParse({
+        Api3ServerV1: contracts?.Api3ServerV1 ? contracts.Api3ServerV1 : references.Api3ServerV1[chainId],
+      });
+      if (!parsedContracts.success) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Invalid contract addresses',
+          path: ['chains', chainId, 'contracts'],
+        });
+
+        return z.NEVER;
+      }
+
+      return [
+        chainId,
+        {
+          ...chain,
+          contracts: parsedContracts.data,
+        },
+      ];
+    })
+  );
+});
+
+export const configSchema = z
+  .object({
+    sponsorWalletMnemonic: z.string().refine((mnemonic) => ethers.utils.isValidMnemonic(mnemonic), 'Invalid mnemonic'),
+    chains: chainsSchema,
+  })
+  .strict();
+
+export type Config = z.infer<typeof configSchema>;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -6,17 +6,21 @@ export const evmAddressSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Must be
 
 export const evmIdSchema = z.string().regex(/^0x[a-fA-F0-9]{64}$/, 'Must be a valid EVM hash');
 
-export const providerSchema = z.object({
-  url: z.string().url(),
-});
+export const providerSchema = z
+  .object({
+    url: z.string().url(),
+  })
+  .strict();
 
 export type Provider = z.infer<typeof providerSchema>;
 
 // Contracts are optional. If unspecified, they will be loaded from "airnode-protocol-v1" or error out during
 // validation. We need a chain ID from parent schema to load the contracts.
-export const optionalContractsSchema = z.object({
-  Api3ServerV1: evmAddressSchema.optional(),
-});
+export const optionalContractsSchema = z
+  .object({
+    Api3ServerV1: evmAddressSchema.optional(),
+  })
+  .strict();
 
 // The contracts are guaraneteed to exist after the configuration is passed, but the inferred type would be optional so
 // we create a new schema just to infer the type correctly.
@@ -24,18 +28,40 @@ const contractsSchema = optionalContractsSchema.required();
 
 export type Contracts = z.infer<typeof contractsSchema>;
 
+export const temporaryBeaconDataSchema = z.object({
+  airnode: evmAddressSchema,
+  templateId: evmIdSchema,
+});
+
+export type TemporaryBeaconData = z.infer<typeof temporaryBeaconDataSchema>;
+
+// The DapiDataRegistry should live on-chain and Airseeker will query the contract for information. However, the
+// contract does not exist as of now, so the data is hardcoded.
+export const temporaryDapiDataRegistrySchema = z.object({
+  airnodeToSignedApiUrl: z.record(z.string()),
+  dataFeedIdToBeacons: z.record(z.array(temporaryBeaconDataSchema)),
+  activeDapiNames: z.array(z.string()),
+});
+
+export type TemporaryDapiDataRegistry = z.infer<typeof temporaryDapiDataRegistrySchema>;
+
 // Contracts are optional. If unspecified, they will be loaded from "airnode-protocol-v1" or error out during
 // validation. We need a chain ID from parent schema to load the contracts.
-export const optionalChainSchema = z.object({
-  providers: z.record(providerSchema), // The record key is the provider "nickname"
-  contracts: optionalContractsSchema.optional(),
-});
+export const optionalChainSchema = z
+  .object({
+    providers: z.record(providerSchema), // The record key is the provider "nickname"
+    __Temporary__DapiDataRegistry: temporaryDapiDataRegistrySchema,
+    contracts: optionalContractsSchema.optional(),
+  })
+  .strict();
 
 // The contracts are guaraneteed to exist after the configuration is passed, but the inferred type would be optional so
 // we create a new schema just to infer the type correctly.
-const chainSchema = optionalChainSchema.extend({
-  contracts: contractsSchema,
-});
+const chainSchema = optionalChainSchema
+  .extend({
+    contracts: contractsSchema,
+  })
+  .strict();
 
 export type Chain = z.infer<typeof chainSchema>;
 

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import template from 'lodash/template';
+import { goSync } from '@api3/promise-utils';
+
+const secretsSchema = z.record(z.string());
+
+export const parseSecrets = (secrets: unknown) => {
+  return secretsSchema.parse(secrets);
+};
+
+// Regular expression that does not match anything, ensuring no escaping or interpolation happens
+// https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L199
+const NO_MATCH_REGEXP = /($^)/;
+// Regular expression matching ES template literal delimiter (${}) with escaping
+// https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L175
+const ES_MATCH_REGEXP = /\$\{([^\\}]*(?:\\.[^\\}]*)*)\}/g;
+
+export const interpolateSecrets = (config: unknown, secrets: Record<string, string | undefined>) => {
+  const goInterpolated = goSync(() =>
+    template(JSON.stringify(config), {
+      escape: NO_MATCH_REGEXP,
+      evaluate: NO_MATCH_REGEXP,
+      interpolate: ES_MATCH_REGEXP,
+    })(secrets)
+  );
+
+  if (!goInterpolated.success) {
+    throw new Error(`Error interpolating secrets. Make sure the secrets format is correct.`, {
+      cause: goInterpolated.error,
+    });
+  }
+
+  const goJson = goSync(() => JSON.parse(goInterpolated.data));
+  if (!goJson.success) {
+    throw new Error('Configuration file is not a valid JSON after secrets interpolation.');
+  }
+
+  return goJson.data;
+};


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/3

This PR is largely inspired by https://github.com/api3dao/signed-api/tree/main/packages/pusher and some of the code is copied over (will be later moved to commons repo). The chain configuration is a small subset of the [old airseeker configuration](https://github.com/api3dao/airseeker/blob/74bf6fc721ac8ae469cc372ec17eebbf890b0517/config/airseeker.example.json#L55).

All properties of the configuration should be documented, but there is no implementation yet. Part of the configuration is `__Temporary__DapiDataRegistry` which is a temporary replacement of `DapiDataRegistry` contract. I think the current form is usable, but it can be freely changed later (since that section will ultimately be removed).