### PR TITLE
Deep beacon set update check

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,5 +4,3 @@ export const HTTP_SIGNED_DATA_API_HEADROOM = 1000;
 export const HUNDRED_PERCENT = 1e8;
 
 export const AIRSEEKER_PROTOCOL_ID = '5'; // From: https://github.com/api3dao/airnode/blob/ef16c54f33d455a1794e7886242567fc47ee14ef/packages/airnode-protocol/src/index.ts#L46
-
-export const MULTICALL_CHUNK_SIZE = 10;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,5 @@ export const HTTP_SIGNED_DATA_API_HEADROOM = 1000;
 export const HUNDRED_PERCENT = 1e8;
 
 export const AIRSEEKER_PROTOCOL_ID = '5'; // From: https://github.com/api3dao/airnode/blob/ef16c54f33d455a1794e7886242567fc47ee14ef/packages/airnode-protocol/src/index.ts#L46
+
+export const MULTICALL_CHUNK_SIZE = 10;

--- a/src/update-feeds/check-feeds.test.ts
+++ b/src/update-feeds/check-feeds.test.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ethers } from 'ethers';
+import { ethers } from 'ethers';
 
 import { init } from '../../test/fixtures/mock-config';
 import { allowPartial } from '../../test/utils';
@@ -7,8 +7,6 @@ import type * as stateModule from '../state';
 import * as contractUtils from './api3-server-v1';
 import { callAndParseMulticall, shallowCheckFeeds } from './check-feeds';
 import type { ReadDapiWithIndexResponse } from './dapi-data-registry';
-
-// jest.mock('../state');
 
 describe('checks whether feeds should be updated or not', () => {
   describe('shallow analysis', () => {
@@ -114,8 +112,7 @@ describe('checks whether feeds should be updated or not', () => {
             tryMulticall: tryMulticallMock,
           },
         }),
-
-        interface: { encodeFunctionData: () => 'does not matter' },
+        interface: { encodeFunctionData: jest.fn().mockReturnValue('does not matter') },
       };
 
       jest.spyOn(contractUtils, 'getApi3ServerV1').mockReturnValue(mockContract as any);

--- a/src/update-feeds/check-feeds.test.ts
+++ b/src/update-feeds/check-feeds.test.ts
@@ -1,0 +1,124 @@
+import { ethers } from 'ethers';
+
+import { init } from '../../test/fixtures/mock-config';
+import { allowPartial } from '../../test/utils';
+import type * as stateModule from '../state';
+
+import * as contractUtils from './api3-server-v1';
+import { callAndParseMulticall, shallowCheckFeeds } from './check-feeds';
+import type { ReadDapiWithIndexResponse } from './dapi-data-registry';
+
+// jest.mock('../state');
+
+describe('checks whether feeds should be updated or not', () => {
+  describe('shallow analysis', () => {
+    it('reports an updatable feed as updatable', () => {
+      init(
+        allowPartial<stateModule.State>({
+          signedApiStore: {
+            '0x000a': { timestamp: '100', encodedValue: ethers.BigNumber.from(200).toHexString() },
+            '0x000b': { timestamp: '150', encodedValue: ethers.BigNumber.from(250).toHexString() },
+            '0x000c': { timestamp: '200', encodedValue: ethers.BigNumber.from(300).toHexString() },
+          },
+        })
+      );
+
+      const batch = allowPartial<ReadDapiWithIndexResponse[]>([
+        {
+          updateParameters: { deviationThresholdInPercentage: 2 },
+          dataFeedValue: { value: ethers.BigNumber.from(1), timestamp: 1 },
+          decodedDataFeed: {
+            dataFeedId: '0x000',
+            beacons: [{ dataFeedId: '0x000a' }, { dataFeedId: '0x000b' }, { dataFeedId: '0x000c' }],
+          },
+          dapiName: 'test',
+        },
+      ]);
+
+      const result = shallowCheckFeeds(batch);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not report a feed that should not be updated', () => {
+      init(
+        allowPartial<stateModule.State>({
+          signedApiStore: {
+            '0x000a': { timestamp: '100', encodedValue: ethers.BigNumber.from(200).toHexString() },
+            '0x000b': { timestamp: '150', encodedValue: ethers.BigNumber.from(250).toHexString() },
+            '0x000c': { timestamp: '200', encodedValue: ethers.BigNumber.from(300).toHexString() },
+          },
+        })
+      );
+
+      const batch = allowPartial<ReadDapiWithIndexResponse[]>([
+        {
+          updateParameters: { deviationThresholdInPercentage: 2 },
+          dataFeedValue: { value: ethers.BigNumber.from(250), timestamp: 150 },
+          decodedDataFeed: {
+            dataFeedId: '0x000',
+            beacons: [{ dataFeedId: '0x000a' }, { dataFeedId: '0x000b' }, { dataFeedId: '0x000c' }],
+          },
+          dapiName: 'test',
+        },
+      ]);
+
+      const result = shallowCheckFeeds(batch);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('deep analysis', () => {
+    it('reports an updatable feed as updatable', async () => {
+      init(
+        allowPartial<stateModule.State>({
+          signedApiStore: {
+            '0x000a': { timestamp: '100', encodedValue: ethers.BigNumber.from(200).toHexString() },
+            '0x000b': { timestamp: '150', encodedValue: ethers.BigNumber.from(250).toHexString() },
+            '0x000c': { timestamp: '200', encodedValue: ethers.BigNumber.from(300).toHexString() },
+          },
+        })
+      );
+
+      const batch = allowPartial<ReadDapiWithIndexResponse[]>([
+        {
+          updateParameters: { deviationThresholdInPercentage: 2 },
+          dataFeedValue: { value: ethers.BigNumber.from(1), timestamp: 1 },
+          decodedDataFeed: {
+            dataFeedId: '0x000',
+            beacons: [
+              { dataFeedId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6' },
+              { dataFeedId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7' },
+              { dataFeedId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8' },
+            ],
+          },
+          dapiName: 'test',
+        },
+      ]);
+
+      const mockContract = {
+        connect: jest.fn().mockReturnValue({
+          callStatic: {
+            tryMulticall: jest.fn().mockReturnValue({
+              successes: [true, true, true],
+              returndata: [
+                ethers.utils.defaultAbiCoder.encode(['int224', 'uint32'], [100, 105]),
+                ethers.utils.defaultAbiCoder.encode(['int224', 'uint32'], [101, 106]),
+                ethers.utils.defaultAbiCoder.encode(['int224', 'uint32'], [102, 107]),
+              ],
+            }),
+          },
+        }),
+      };
+
+      jest.spyOn(contractUtils, 'getApi3ServerV1').mockReturnValue(mockContract as any);
+
+      const shallowFeedsToUpdate = shallowCheckFeeds(batch);
+
+      const multicallPromise = await callAndParseMulticall(shallowFeedsToUpdate, 'hardhat', '31337');
+
+      await expect(multicallPromise).resolves.toBe([]);
+    });
+  });
+});

--- a/src/update-feeds/check-feeds.ts
+++ b/src/update-feeds/check-feeds.ts
@@ -59,6 +59,10 @@ export const callAndParseMulticall = async (
       calldata: server.interface.encodeFunctionData('dataFeeds', [dataFeedId]),
     }));
 
+  if (feedCalldata.length === 0) {
+    return [];
+  }
+
   const multicallResult = await go(
     async () => server.connect(voidSigner).callStatic.tryMulticall(feedCalldata.map((feed) => feed.calldata)),
     { retries: 1 }

--- a/src/update-feeds/check-feeds.ts
+++ b/src/update-feeds/check-feeds.ts
@@ -111,7 +111,7 @@ export const callAndParseMulticall = async (
         return true;
       }
 
-      return numericalSignedTimestamp > Date.now() + 60 * 60;
+      return numericalSignedTimestamp > Date.now() / 1000 + 60 * 60;
     });
 };
 
@@ -142,7 +142,7 @@ export const getFeedsToUpdate = async (
           return latestOnChainValue.onChainValue;
         }
 
-        const storeDatapoint = getStoreDataPoint(feed.decodedDataFeed.dataFeedId);
+        const storeDatapoint = getStoreDataPoint(beacon.dataFeedId);
 
         const value = ethers.BigNumber.from(storeDatapoint?.encodedValue ?? '1');
         const timestamp = ethers.BigNumber.from(storeDatapoint?.timestamp ?? 1);

--- a/src/update-feeds/check-feeds.ts
+++ b/src/update-feeds/check-feeds.ts
@@ -116,7 +116,7 @@ export const callAndParseMulticall = async (
 };
 
 export const getFeedsToUpdate = async (
-  batch: ReadDapiWithIndexResponse[], // ReturnType<typeof getFeedsToUpdate>,
+  batch: ReadDapiWithIndexResponse[],
   providerName: Provider,
   chainId: ChainId
 ) => {

--- a/src/update-feeds/check-feeds.ts
+++ b/src/update-feeds/check-feeds.ts
@@ -1,0 +1,174 @@
+import { go } from '@api3/promise-utils';
+import { ethers } from 'ethers';
+import { uniqBy } from 'lodash';
+
+import { calculateMedian, checkUpdateConditions } from '../condition-check';
+import { logger } from '../logger';
+import { getStoreDataPoint } from '../signed-data-store';
+import { getState } from '../state';
+import type { ChainId, Provider } from '../types';
+
+import { getApi3ServerV1 } from './api3-server-v1';
+import type { ReadDapiWithIndexResponse } from './dapi-data-registry';
+
+export const shallowCheckFeeds = (batch: ReadDapiWithIndexResponse[]) =>
+  batch
+    .map((dapiResponse: ReadDapiWithIndexResponse) => ({
+      ...dapiResponse,
+      signedData: dapiResponse.decodedDataFeed.beacons.map(({ dataFeedId }) => getStoreDataPoint(dataFeedId)),
+    }))
+    .filter(({ signedData, updateParameters, dataFeedValue }) => {
+      if (!signedData) {
+        return false;
+      }
+
+      const offChainValue =
+        calculateMedian(signedData.map((point) => ethers.BigNumber.from(point?.encodedValue ?? 0))) ??
+        ethers.BigNumber.from(1);
+      const offChainTimestamp =
+        calculateMedian(signedData.map((point) => ethers.BigNumber.from(point?.timestamp ?? 0)))?.toNumber() ?? 1;
+      const deviationThreshold = updateParameters.deviationThresholdInPercentage;
+
+      return checkUpdateConditions(
+        dataFeedValue.value,
+        dataFeedValue.timestamp,
+        offChainValue,
+        offChainTimestamp,
+        updateParameters.heartbeatInterval,
+        deviationThreshold
+      );
+    });
+
+export const callAndParseMulticall = async (
+  batch: ReturnType<typeof shallowCheckFeeds>,
+  providerName: Provider,
+  chainId: ChainId
+) => {
+  const { config } = getState();
+  const chain = config.chains[chainId]!;
+  const { providers, contracts } = chain;
+
+  const provider = new ethers.providers.StaticJsonRpcProvider(providers[providerName]);
+  const server = getApi3ServerV1(contracts.Api3ServerV1, provider);
+  const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
+
+  const feedCalldata = uniqBy(batch.flat(), 'dataFeedId')
+    .flatMap((parentFeed) => parentFeed.decodedDataFeed.beacons)
+    .map(({ dataFeedId }) => ({
+      dataFeedId,
+      calldata: server.interface.encodeFunctionData('dataFeeds', [dataFeedId]),
+    }));
+
+  const multicallResult = await go(
+    async () => server.connect(voidSigner).callStatic.tryMulticall(feedCalldata.map((feed) => feed.calldata)),
+    { retries: 1 }
+  );
+
+  if (!multicallResult.success) {
+    logger.warn(`The multicall attempt to read potentially updateable feed values has failed.`, {
+      error: multicallResult.error,
+    });
+    throw multicallResult.error;
+  }
+
+  const { successes, returndata } = multicallResult.data;
+  if (!(successes.length === feedCalldata.length && returndata.length === feedCalldata.length)) {
+    throw new Error(`The number of returned records from the read multicall call does not match the number requested.`);
+  }
+
+  return feedCalldata
+    .map(({ dataFeedId }, idx) => {
+      if (successes[idx]) {
+        const [value, timestamp] = ethers.utils.defaultAbiCoder.decode(['int224', 'uint32'], returndata[idx]!);
+
+        return {
+          dataFeedId,
+          onChainValue: { timestamp: ethers.BigNumber.from(timestamp), value: ethers.BigNumber.from(value) },
+        };
+      }
+
+      return { dataFeedId, onChainValue: undefined };
+    })
+    .filter(({ dataFeedId, onChainValue }) => {
+      if (!onChainValue) {
+        return false;
+      }
+
+      const signedData = getStoreDataPoint(dataFeedId);
+      if (!signedData) {
+        return false;
+      }
+
+      const numericalSignedTimestamp = Number.parseInt(signedData.timestamp, 10);
+      const numericalOnChainTimestamp = onChainValue.timestamp.toNumber();
+
+      // https://github.com/api3dao/airnode-protocol-v1/blob/fa95f043ce4b50e843e407b96f7ae3edcf899c32/contracts/api3-server-v1/DataFeedServer.sol#L121
+      if (numericalSignedTimestamp < numericalOnChainTimestamp) {
+        return true;
+      }
+
+      return numericalSignedTimestamp > Date.now() + 60 * 60;
+    });
+};
+
+export const getFeedsToUpdate = async (
+  batch: ReadDapiWithIndexResponse[], // ReturnType<typeof getFeedsToUpdate>,
+  providerName: Provider,
+  chainId: ChainId
+) => {
+  const shallowCheckedFeedsToUpdate = shallowCheckFeeds(batch);
+
+  const feedsThatWouldFailToUpdateResult = await go(
+    async () => callAndParseMulticall(shallowCheckedFeedsToUpdate, providerName, chainId),
+    { retries: 0 }
+  );
+  if (!feedsThatWouldFailToUpdateResult.success) {
+    return batch;
+  }
+
+  const feedsThatWouldFailToUpdate = feedsThatWouldFailToUpdateResult.data;
+
+  return batch
+    .map((feed) => {
+      const beaconValues = feed.decodedDataFeed.beacons.map((beacon) => {
+        const latestOnChainValue = feedsThatWouldFailToUpdate.find(
+          (failedFeed) => failedFeed.dataFeedId === beacon.dataFeedId && failedFeed.onChainValue
+        );
+        if (latestOnChainValue?.onChainValue) {
+          return latestOnChainValue.onChainValue;
+        }
+
+        const storeDatapoint = getStoreDataPoint(feed.decodedDataFeed.dataFeedId);
+
+        const value = ethers.BigNumber.from(storeDatapoint?.encodedValue ?? '1');
+        const timestamp = ethers.BigNumber.from(storeDatapoint?.timestamp ?? 1);
+
+        return { timestamp, value };
+      });
+
+      const newMedianValue = calculateMedian(beaconValues.map((val) => val.value));
+      const newMedianTimestamp = calculateMedian(beaconValues.map((val) => val.timestamp));
+
+      const shouldUpdate = checkUpdateConditions(
+        feed.dataFeedValue.value,
+        feed.dataFeedValue.timestamp,
+        newMedianValue ?? ethers.BigNumber.from(0),
+        newMedianTimestamp?.toNumber() ?? 0,
+        feed.updateParameters.heartbeatInterval,
+        feed.updateParameters.deviationThresholdInPercentage
+      );
+
+      // filter out underlying beacons that failed to update
+      return {
+        ...feed,
+        decodedDataFeed: {
+          ...feed.decodedDataFeed,
+          beacons: feed.decodedDataFeed.beacons.filter(
+            (beacon) => !feedsThatWouldFailToUpdate.some((childFeed) => childFeed.dataFeedId === beacon.dataFeedId)
+          ),
+        },
+        shouldUpdate,
+      };
+    })
+    .filter((feed) => feed.shouldUpdate);
+};

--- a/src/update-feeds/update-feeds.test.ts
+++ b/src/update-feeds/update-feeds.test.ts
@@ -174,7 +174,7 @@ describe(runUpdateFeed.name, () => {
         signedApiUrlStore: { '31337': { 'some-test-provider': ['url-one'] } },
         signedApiStore: {},
         gasPriceStore: {
-          '123': {
+          '31337': {
             'some-test-provider': {
               gasPrices: [],
               sponsorLastUpdateTimestampMs: {
@@ -187,16 +187,16 @@ describe(runUpdateFeed.name, () => {
     );
 
     await runUpdateFeed(
-      'provider-name',
+      'some-test-provider',
       allowPartial<Chain>({
         dataFeedBatchSize: 1,
         dataFeedUpdateInterval: 0.15,
-        providers: { ['provider-name']: { url: 'provider-url' } },
+        providers: { ['some-test-provider']: { url: 'provider-url' } },
         contracts: {
           DapiDataRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
         },
       }),
-      '123'
+      '31337'
     );
 
     // Expect the contract to fetch the batches to be called with the correct stagger time.

--- a/src/update-feeds/update-feeds.test.ts
+++ b/src/update-feeds/update-feeds.test.ts
@@ -171,11 +171,11 @@ describe(runUpdateFeed.name, () => {
     jest.spyOn(stateModule, 'getState').mockReturnValue(
       allowPartial<stateModule.State>({
         config: testConfig,
-        signedApiUrlStore: { '31337': { 'some-test-provider': ['url-one'] } },
+        signedApiUrlStore: { '31337': { hardhat: ['url-one'] } },
         signedApiStore: {},
         gasPriceStore: {
           '31337': {
-            'some-test-provider': {
+            hardhat: {
               gasPrices: [],
               sponsorLastUpdateTimestampMs: {
                 '0xdatafeedId': 100,
@@ -187,11 +187,11 @@ describe(runUpdateFeed.name, () => {
     );
 
     await runUpdateFeed(
-      'some-test-provider',
+      'hardhat',
       allowPartial<Chain>({
         dataFeedBatchSize: 1,
         dataFeedUpdateInterval: 0.15,
-        providers: { ['some-test-provider']: { url: 'provider-url' } },
+        providers: { hardhat: { url: 'http://127.0.0.1:8545' } },
         contracts: {
           DapiDataRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
         },

--- a/src/update-feeds/update-feeds.ts
+++ b/src/update-feeds/update-feeds.ts
@@ -1,6 +1,6 @@
 import { go } from '@api3/promise-utils';
 import { ethers } from 'ethers';
-import { chunk, range, size } from 'lodash';
+import { chunk, range, size, uniqBy } from 'lodash';
 
 import { calculateMedian, checkUpdateConditions } from '../condition-check';
 import type { Chain } from '../config/schema';
@@ -128,8 +128,25 @@ export const runUpdateFeed = async (providerName: Provider, chain: Chain, chainI
   });
 };
 
-export const getFeedsToUpdate = (batch: ReadDapiWithIndexResponse[]) =>
-  batch
+export const updateFeeds = async (_batch: ReturnType<typeof getFeedsToUpdate>, _chainId: string) => {
+  // TODO implement
+  // batch, execute
+};
+
+export const getFeedsToUpdate = async (
+  batch: ReadDapiWithIndexResponse[], // ReturnType<typeof getFeedsToUpdate>,
+  providerName: Provider,
+  chainId: ChainId
+) => {
+  const { config } = getState();
+  const chain = config.chains[chainId]!;
+  const { providers, contracts } = chain;
+
+  const provider = new ethers.providers.StaticJsonRpcProvider(providers[providerName]);
+  const server = getApi3ServerV1(contracts.Api3ServerV1, provider);
+  const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
+
+  const shallowCheckedFeedsToUpdate = batch
     .map((dapiResponse: ReadDapiWithIndexResponse) => {
       const signedData = getStoreDataPoint(dapiResponse.decodedDataFeed.dataFeedId);
 
@@ -147,8 +164,6 @@ export const getFeedsToUpdate = (batch: ReadDapiWithIndexResponse[]) =>
       const offChainTimestamp = Number.parseInt(signedData?.timestamp ?? '0', 10);
       const deviationThreshold = updateParameters.deviationThresholdInPercentage;
 
-      // TODO clear last update timestamps if an update is not needed
-
       return checkUpdateConditions(
         dataFeedValue.value,
         dataFeedValue.timestamp,
@@ -159,75 +174,67 @@ export const getFeedsToUpdate = (batch: ReadDapiWithIndexResponse[]) =>
       );
     });
 
-export const updateFeeds = async (_batch: ReturnType<typeof getFeedsToUpdate>, _chainId: string) => {
-  // TODO implement
-  // batch, execute
-};
-
-export const deepCheckFeeds = async (
-  batch: ReturnType<typeof getFeedsToUpdate>,
-  providerName: Provider,
-  chainId: ChainId
-) => {
-  const { config } = getState();
-  const chain = config.chains[chainId]!;
-  const { providers, contracts } = chain;
-
-  const provider = new ethers.providers.StaticJsonRpcProvider(providers[providerName]);
-  const server = getApi3ServerV1(contracts.Api3ServerV1, provider);
-  const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
-
-  // We surely have to chunk these? they'll get big.
   const updateCalldataBatches = chunk(
-    batch
-      .flatMap((parent) => parent.decodedDataFeed.beacons)
-      .map((beacon) => {
-        const datapoint = getStoreDataPoint(beacon.dataFeedId);
-        if (!datapoint) {
+    uniqBy(
+      shallowCheckedFeedsToUpdate
+        .flatMap((parent) => parent.decodedDataFeed.beacons)
+        .map((beacon) => {
+          const datapoint = getStoreDataPoint(beacon.dataFeedId);
+          if (!datapoint) {
+            return {
+              dataFeedId: beacon.dataFeedId,
+              calldata: [],
+            };
+          }
+
+          const { timestamp, encodedValue, signature } = datapoint;
+
           return {
             dataFeedId: beacon.dataFeedId,
-            calldata: [],
+            calldata: server.interface.encodeFunctionData('updateBeaconWithSignedData', [
+              beacon.airnodeAddress,
+              beacon.templateId,
+              timestamp,
+              encodedValue,
+              signature,
+            ]),
           };
-        }
-
-        const { timestamp, encodedValue, signature } = datapoint;
-
-        return {
-          dataFeedId: beacon.dataFeedId,
-          calldata: server.interface.encodeFunctionData('updateBeaconWithSignedData', [
-            beacon.airnodeAddress,
-            beacon.templateId,
-            timestamp,
-            encodedValue,
-            signature,
-          ]),
-        };
-      })
-      .filter((calldata) => calldata.calldata.length === 0),
+        })
+        .filter((calldata) => calldata.calldata.length === 0),
+      'dataFeedId'
+    ),
     MULTICALL_CHUNK_SIZE
   );
 
-  // TODO deduplicate feeds based on ID
   // TODO timeouts
   const updateCalldataResults = await Promise.all(
-    updateCalldataBatches.map(async (ucdb) => {
+    updateCalldataBatches.map(async (updateCalldataBatch) => {
       const multicallResult = await go(
-        async () => server.connect(voidSigner).callStatic.tryMulticall(ucdb.map((item) => item.calldata)),
+        async () =>
+          server.connect(voidSigner).callStatic.tryMulticall(updateCalldataBatch.map((item) => item.calldata)),
         { retries: 1 }
       );
       if (!multicallResult.success) {
-        // TODO log failure
-        return ucdb.map((feed) => ({ dataFeedId: feed.dataFeedId, shouldUpdate: true }));
+        logger.warn(`The multicall static-call attempt to update feeds has failed.`, { error: multicallResult.error });
+        return updateCalldataBatch.map((feed) => ({ dataFeedId: feed.dataFeedId, shouldUpdate: true }));
       }
 
-      const { successes } = multicallResult.data;
+      const { successes, returndata } = multicallResult.data;
+      if (!(successes.length === updateCalldataBatch.length && returndata.length === updateCalldataBatch.length)) {
+        logger.warn(
+          `The number of returned records from the updateCalldata multicall batch does not match the number requested.`
+        );
+        return updateCalldataBatch.map((feed) => ({ dataFeedId: feed.dataFeedId, shouldUpdate: true }));
+      }
 
-      return ucdb.map((feed, idx) => ({ shouldUpdate: !!successes[idx], dataFeedId: feed.dataFeedId }));
+      return updateCalldataBatch.map((feed, idx) => ({ shouldUpdate: !!successes[idx], dataFeedId: feed.dataFeedId }));
     })
   );
 
   const failedFeedUpdateValueCalldata = await Promise.all(
+    // Chunk the feeds to reduce the likelyhood of the multicall failing due to exceeded gas limit
     chunk(
+      // deduplicate the feeds to be queried
       updateCalldataResults
         .flat()
         .filter((updateAttemptResult) => !updateAttemptResult.shouldUpdate)
@@ -242,11 +249,17 @@ export const deepCheckFeeds = async (
         { retries: 1 }
       );
       if (!multicallResult.success) {
-        // TODO log failure
+        logger.warn(`The multicall attempt to read feed values that previously failed to update has failed.`, {
+          error: multicallResult.error,
+        });
         return feedBatch.map((feed) => ({ dataFeedId: feed.dataFeedId, onChainValue: undefined }));
       }
 
       const { successes, returndata } = multicallResult.data;
+      if (!(successes.length === feedBatch.length && returndata.length === feedBatch.length)) {
+        logger.warn(`The number of returned records from the multicall batch does not match the number requested.`);
+        return feedBatch.map((feed) => ({ dataFeedId: feed.dataFeedId, onChainValue: undefined }));
+      }
 
       return multicallResult.data.map((_, idx) => {
         if (successes[idx]) {
@@ -262,7 +275,7 @@ export const deepCheckFeeds = async (
 
   const flattenedFailedFeedValues = failedFeedUpdateValueCalldata.flat();
 
-  const filteredBatch = batch
+  return batch
     .map((feed) => {
       const beaconValues = feed.decodedDataFeed.beacons.map((beacon) => {
         const latestOnChainValue = flattenedFailedFeedValues.find(
@@ -305,10 +318,6 @@ export const deepCheckFeeds = async (
       };
     })
     .filter((feed) => feed.shouldUpdate);
-
-  // TODO add logger+context
-
-  return filteredBatch;
 };
 
 export const processBatch = async (batch: ReadDapiWithIndexResponse[], providerName: Provider, chainId: ChainId) => {
@@ -335,9 +344,7 @@ export const processBatch = async (batch: ReadDapiWithIndexResponse[], providerN
     }
   });
 
-  const initialFeedsToUpdate = getFeedsToUpdate(batch);
+  const feedsToUpdate = getFeedsToUpdate(batch, chainId, providerName);
 
-  const finalFeedsToUpdate = await deepCheckFeeds(initialFeedsToUpdate, chainId, providerName);
-
-  return updateFeeds(finalFeedsToUpdate, chainId);
+  return updateFeeds(feedsToUpdate, chainId);
 };

--- a/src/update-feeds/update-feeds.ts
+++ b/src/update-feeds/update-feeds.ts
@@ -1,16 +1,14 @@
 import { go } from '@api3/promise-utils';
 import { ethers } from 'ethers';
-import { range, size, uniqBy } from 'lodash';
+import { range, size } from 'lodash';
 
-import { calculateMedian, checkUpdateConditions } from '../condition-check';
 import type { Chain } from '../config/schema';
 import { logger } from '../logger';
-import { getStoreDataPoint } from '../signed-data-store';
 import { getState, updateState } from '../state';
 import type { ChainId, Provider } from '../types';
 import { isFulfilled, sleep } from '../utils';
 
-import { getApi3ServerV1 } from './api3-server-v1';
+import { getFeedsToUpdate } from './check-feeds';
 import {
   decodeDapisCountResponse,
   decodeReadDapiWithIndexResponse,
@@ -130,151 +128,6 @@ export const runUpdateFeed = async (providerName: Provider, chain: Chain, chainI
 export const updateFeeds = async (_batch: ReturnType<typeof getFeedsToUpdate>, _chainId: string) => {
   // TODO implement
   // batch, execute
-};
-
-export const getFeedsToUpdate = async (
-  batch: ReadDapiWithIndexResponse[], // ReturnType<typeof getFeedsToUpdate>,
-  providerName: Provider,
-  chainId: ChainId
-) => {
-  const { config } = getState();
-  const chain = config.chains[chainId]!;
-  const { providers, contracts } = chain;
-
-  const provider = new ethers.providers.StaticJsonRpcProvider(providers[providerName]);
-  const server = getApi3ServerV1(contracts.Api3ServerV1, provider);
-  const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
-
-  const shallowCheckedFeedsToUpdate = batch
-    .map((dapiResponse: ReadDapiWithIndexResponse) => {
-      const signedData = getStoreDataPoint(dapiResponse.decodedDataFeed.dataFeedId);
-
-      return {
-        ...dapiResponse,
-        signedData,
-      };
-    })
-    .filter(({ signedData, updateParameters, dataFeedValue }) => {
-      if (!signedData) {
-        return false;
-      }
-
-      const offChainValue = ethers.BigNumber.from(signedData.encodedValue);
-      const offChainTimestamp = Number.parseInt(signedData?.timestamp ?? '0', 10);
-      const deviationThreshold = updateParameters.deviationThresholdInPercentage;
-
-      return checkUpdateConditions(
-        dataFeedValue.value,
-        dataFeedValue.timestamp,
-        offChainValue,
-        offChainTimestamp,
-        updateParameters.heartbeatInterval,
-        deviationThreshold
-      );
-    });
-
-  const feedCalldata = uniqBy(shallowCheckedFeedsToUpdate.flat(), 'dataFeedId')
-    .flatMap((parentFeed) => parentFeed.decodedDataFeed.beacons)
-    .map(({ dataFeedId }) => ({
-      dataFeedId,
-      calldata: server.interface.encodeFunctionData('dataFeeds', [dataFeedId]),
-    }));
-
-  const multicallResult = await go(
-    async () => server.connect(voidSigner).callStatic.tryMulticall(feedCalldata.map((feed) => feed.calldata)),
-    { retries: 1 }
-  );
-
-  if (!multicallResult.success) {
-    logger.warn(`The multicall attempt to read potentially updateable feed values has failed.`, {
-      error: multicallResult.error,
-    });
-    return shallowCheckedFeedsToUpdate;
-  }
-
-  const { successes, returndata } = multicallResult.data;
-  if (!(successes.length === feedCalldata.length && returndata.length === feedCalldata.length)) {
-    logger.warn(`The number of returned records from the read multicall call does not match the number requested.`);
-    return shallowCheckedFeedsToUpdate;
-  }
-
-  const feedsThatWouldFailToUpdate = feedCalldata
-    .map(({ dataFeedId }, idx) => {
-      if (successes[idx]) {
-        const [value, timestamp] = ethers.utils.defaultAbiCoder.decode(['int224', 'uint32'], returndata[idx]!);
-
-        return {
-          dataFeedId,
-          onChainValue: { timestamp: ethers.BigNumber.from(timestamp), value: ethers.BigNumber.from(value) },
-        };
-      }
-
-      return { dataFeedId, onChainValue: undefined };
-    })
-    .filter(({ dataFeedId, onChainValue }) => {
-      if (!onChainValue) {
-        return false;
-      }
-
-      const signedData = getStoreDataPoint(dataFeedId);
-      if (!signedData) {
-        return false;
-      }
-
-      const numericalSignedTimestamp = Number.parseInt(signedData.timestamp, 10);
-      const numericalOnChainTimestamp = onChainValue.timestamp.toNumber();
-
-      // https://github.com/api3dao/airnode-protocol-v1/blob/fa95f043ce4b50e843e407b96f7ae3edcf899c32/contracts/api3-server-v1/DataFeedServer.sol#L121
-      if (numericalSignedTimestamp < numericalOnChainTimestamp) {
-        return true;
-      }
-
-      return numericalSignedTimestamp > Date.now() + 60 * 60;
-    });
-
-  return batch
-    .map((feed) => {
-      const beaconValues = feed.decodedDataFeed.beacons.map((beacon) => {
-        const latestOnChainValue = feedsThatWouldFailToUpdate.find(
-          (failedFeed) => failedFeed.dataFeedId === beacon.dataFeedId && failedFeed.onChainValue
-        );
-        if (latestOnChainValue?.onChainValue) {
-          return latestOnChainValue.onChainValue;
-        }
-
-        const storeDatapoint = getStoreDataPoint(feed.decodedDataFeed.dataFeedId);
-
-        const value = ethers.BigNumber.from(storeDatapoint?.encodedValue ?? '1');
-        const timestamp = ethers.BigNumber.from(storeDatapoint?.timestamp ?? 1);
-
-        return { timestamp, value };
-      });
-
-      const newMedianValue = calculateMedian(beaconValues.map((val) => val.value));
-      const newMedianTimestamp = calculateMedian(beaconValues.map((val) => val.timestamp));
-
-      const shouldUpdate = checkUpdateConditions(
-        feed.dataFeedValue.value,
-        feed.dataFeedValue.timestamp,
-        newMedianValue ?? ethers.BigNumber.from(0),
-        newMedianTimestamp?.toNumber() ?? 0,
-        feed.updateParameters.heartbeatInterval,
-        feed.updateParameters.deviationThresholdInPercentage
-      );
-
-      // filter out underlying beacons that failed to update
-      return {
-        ...feed,
-        decodedDataFeed: {
-          ...feed.decodedDataFeed,
-          beacons: feed.decodedDataFeed.beacons.filter(
-            (beacon) => !feedsThatWouldFailToUpdate.some((childFeed) => childFeed.dataFeedId === beacon.dataFeedId)
-          ),
-        },
-        shouldUpdate,
-      };
-    })
-    .filter((feed) => feed.shouldUpdate);
 };
 
 export const processBatch = async (batch: ReadDapiWithIndexResponse[], providerName: Provider, chainId: ChainId) => {


### PR DESCRIPTION
This PR:
- Starts by executing the existing shallow beacon set check based on the datafeed's value returned from the chain during the batch call.
- For all feeds appearing to need an update it when reads the latest values of the children of those feeds and does two timestamp checks to confirm the feeds are indeed updatable.
- Child feeds that are not updatable have their on chain values used in a second/follow-up threshold assessment. If during that check the calcualted values don't exceed the deviation threshold the feeds are not updated. 
- Lastly, updatable child feeds are propagated to the updateFeeds function such that those feeds are not updated during the batch.

This PR also fixes a bug that PR #84 addresses, so will result in some merge conflicts. 

Closes #67 