### PR TITLE
Run airseeker locally

### DIFF
--- a/local-test-configuration/README.md
+++ b/local-test-configuration/README.md
@@ -1,16 +1,16 @@
 # Local Airseeker test
 
-The idea was to use the Docker images for Pusher, Signed API and Airseeker and run them locally. Specifically, I opted
-for the following setup:
+The idea is to use the Docker images for Pusher, Signed API and Airseeker and run them locally. Specifically, this is
+the setup:
 
-- Use 2 pushers with Nodary API and reasonable fetch limits. Each pusher has a different Airnode mnemonic to mimick a
+- Use 2 pushers with Nodary API and reasonable fetch limits. Each pusher has a different Airnode mnemonic to mimic a
   different API. One of the APIs is delayed so that the beacons have different values.
 - Use 2 signed APIs and each Pusher pushes to a separate Signed API.
 - We run Airseeker only on Hardhat network for setup simplicity. Initially, I wanted to have a Polygon testnet as well,
   but gave up on that idea for now.
 
-All configurations are based on the example files, but have been slightly modified. I had to also choose a more volatile
-assets from Nodary API to see Airseeker updates.
+All configurations are based on the example files, but have been slightly modified. I had to also choose more volatile
+assets from the Nodary API to see Airseeker updates.
 
 ## Instructions
 
@@ -60,8 +60,8 @@ pnpm run dev:eth-node
 pnpm ts-node -T ./local-test-configuration/scripts/initialize-chain.ts
 ```
 
-This command gives you the addresses of the deployed contracts. These need to be put to Airseeker secrets and are
-required also for the monitoring page.
+This command gives you the addresses of the deployed contracts. These need to be put into the Airseeker secrets and are
+also required for the monitoring page.
 
 - Open the monitoring page located in `local-test-configuration/monitoring/index.html` in a browser with the following
   query parameters appended
@@ -83,4 +83,4 @@ docker run -it --init --volume $(pwd)/local-test-configuration/airseeker:/app/co
 
 - Monitor the logs of each service, pay attention to errors, warnings and possible improvements.
 - Use the monitoring page to see if the feeds update when they should.
-- I also tried changing the batch size in Airseeker to 1 and Airseeker worked as expected (but was more chattier).
+- You can play with the batch size (e.g. set it to 1) to see the difference in execution.

--- a/local-test-configuration/README.md
+++ b/local-test-configuration/README.md
@@ -1,0 +1,86 @@
+# Local Airseeker test
+
+The idea was to use the Docker images for Pusher, Signed API and Airseeker and run them locally. Specifically, I opted
+for the following setup:
+
+- Use 2 pushers with Nodary API and reasonable fetch limits. Each pusher has a different Airnode mnemonic to mimick a
+  different API. One of the APIs is delayed so that the beacons have different values.
+- Use 2 signed APIs and each Pusher pushes to a separate Signed API.
+- We run Airseeker only on Hardhat network for setup simplicity. Initially, I wanted to have a Polygon testnet as well,
+  but gave up on that idea for now.
+
+All configurations are based on the example files, but have been slightly modified. I had to also choose a more volatile
+assets from Nodary API to see Airseeker updates.
+
+## Instructions
+
+- Create each configuration file from `*.example*` in all folders. Inspect each env file, read the comments and fill in
+  missing secrets. Some of the secrets are the deployed contract addresses, which you'll get by following the next
+  instructions.
+
+- Build all of the Docker containers. Do build containers for Pusher and Signed API you need to run
+  [this command](https://github.com/api3dao/signed-api/blob/0bad6fc8dd6aaffaa12cf099ab6bbf7c98d487c8/package.json#L11)
+  from the signed-api repository. For Airseeker, you can run `pnpm docker:build` from the root of this repository.
+
+- Start Signed API 1 on port `4001` (in a separate terminal):
+
+```sh
+docker run --publish 4001:8090 -it --init --volume $(pwd)/local-test-configuration/signed-api-1:/app/config --env-file ./local-test-configuration/signed-api-1/.env --rm --memory=256m api3/signed-api:latest
+```
+
+- Start Signed API 2 on port `4002` (in a separate terminal):
+
+```sh
+docker run --publish 4002:8090 -it --init --volume $(pwd)/local-test-configuration/signed-api-2:/app/config --env-file ./local-test-configuration/signed-api-2/.env --rm --memory=256m api3/signed-api:latest
+```
+
+You can go to `http://localhost:4001/` and `http://localhost:4002/` to see the Signed API 1 and 2 respectively.
+
+- Start Pusher 1 (in a separate terminal):
+
+```sh
+docker run -it --init --volume $(pwd)/local-test-configuration/pusher-1:/app/config --network host --env-file ./local-test-configuration/pusher-1/.env --rm --memory=256m api3/pusher:latest
+```
+
+- Start Pusher 2 (in a separate terminal):
+
+```sh
+docker run -it --init --volume $(pwd)/local-test-configuration/pusher-2:/app/config --network host --env-file ./local-test-configuration/pusher-2/.env --rm --memory=256m api3/pusher:latest
+```
+
+- Start Hardhat node (in a separate terminal):
+
+```sh
+pnpm run dev:eth-node
+```
+
+- Deploy the test contracts and fund respective Airseeker sponsor wallets:
+
+```sh
+pnpm ts-node -T ./local-test-configuration/scripts/initialize-chain.ts
+```
+
+This command gives you the addresses of the deployed contracts. These need to be put to Airseeker secrets and are
+required also for the monitoring page.
+
+- Open the monitoring page located in `local-test-configuration/monitoring/index.html` in a browser with the following
+  query parameters appended
+  `api3ServerV1Address=<DEPLOYED_API3_SERVER_V1_ADDRESS>&dapiDataRegistryAddress=<DEPLOYED_DAPI_DATA_REGISTRY_ADDRESS>`
+  and open console.
+
+Initially, you should see errors because the beacons are not initialized. After you run Airseeker, it will do the
+updates and the errors should be gone. The page constantly polls the chain and respective signed APIs and compares the
+on-chain and off-chain values. If the deviation exceeds the treshold, the value is marked bold and should be updated by
+Airseeker shortly.
+
+- Run the Airseeker:
+
+```sh
+docker run -it --init --volume $(pwd)/local-test-configuration/airseeker:/app/config --network host --env-file .env --rm api3/airseeker-v2:latest
+```
+
+## Final notes
+
+- Monitor the logs of each service, pay attention to errors, warnings and possible improvements.
+- Use the monitoring page to see if the feeds update when they should.
+- I also tried changing the batch size in Airseeker to 1 and Airseeker worked as expected (but was more chattier).

--- a/local-test-configuration/airseeker/.env.example
+++ b/local-test-configuration/airseeker/.env.example
@@ -1,0 +1,4 @@
+LOGGER_ENABLED=true
+LOG_COLORIZE=true
+LOG_FORMAT=pretty
+LOG_LEVEL=info

--- a/local-test-configuration/airseeker/airseeker.example.json
+++ b/local-test-configuration/airseeker/airseeker.example.json
@@ -1,0 +1,27 @@
+{
+  "sponsorWalletMnemonic": "${SPONSOR_WALLET_MNEMONIC}",
+  "chains": {
+    "31337": {
+      "contracts": {
+        "Api3ServerV1": "${API3_SERVER_V1_ADDRESS}",
+        "DapiDataRegistry": "${DAPI_DATA_REGISTRY_ADDRESS}"
+      },
+      "providers": {
+        "hardhat": {
+          "url": "http://${LOCALHOST_IP}:8545"
+        }
+      },
+      "gasSettings": {
+        "recommendedGasPriceMultiplier": 1.5,
+        "sanitizationSamplingWindow": 15,
+        "sanitizationPercentile": 80,
+        "scalingWindow": 2,
+        "maxScalingMultiplier": 2
+      },
+      "dataFeedUpdateInterval": 30,
+      "dataFeedBatchSize": 10
+    }
+  },
+  "deviationThresholdCoefficient": 1,
+  "signedDataFetchInterval": 10
+}

--- a/local-test-configuration/airseeker/secrets.example.env
+++ b/local-test-configuration/airseeker/secrets.example.env
@@ -1,0 +1,10 @@
+# Secrets must NOT be quoted.
+#
+# NOTE: Generate a mnemonic for Airseeker.
+SPONSOR_WALLET_MNEMONIC=
+# NOTE: Use "host.docker.internal" if using Docker for Desktop.
+LOCALHOST_IP=localhost
+# NOTE: Use instructions to deploy the contracts and paste the Api3ServerV1 address.
+API3_SERVER_V1_ADDRESS=
+# NOTE: Use instructions to deploy the contracts and paste the DapiDataRegistry address.
+DAPI_DATA_REGISTRY_ADDRESS=

--- a/local-test-configuration/monitoring/index.html
+++ b/local-test-configuration/monitoring/index.html
@@ -1,0 +1,1602 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Airseeker monitoring</title>
+  </head>
+
+  <body>
+    <h1>Airseeker monitoring</h1>
+    <p>
+      Uses a fixed (static) configuration to fetch on-chain values of active dAPIs and signed API data and computes the
+      deviation treshold.
+    </p>
+
+    <h2>Active dAPIs</h2>
+    <p>Number of active dAPIs: <span id="activeDapisCount"></span></p>
+    <pre id="activeDapis"></pre>
+  </body>
+  <script
+    src="https://cdnjs.cloudflare.com/ajax/libs/ethers/5.7.2/ethers.umd.min.js"
+    integrity="sha512-FDcVY+g7vc5CXANbrTSg1K5qLyriCsGDYCE02Li1tXEYdNQPvLPHNE+rT2Mjei8N7fZbe0WLhw27j2SrGRpdMg=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  ></script>
+  <script>
+    const api3ServerV1Abi = [
+      {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'dapiName',
+            type: 'bytes32',
+          },
+          {
+            indexed: false,
+            internalType: 'address',
+            name: 'sender',
+            type: 'address',
+          },
+        ],
+        name: 'SetDapiName',
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'beaconSetId',
+            type: 'bytes32',
+          },
+          {
+            indexed: false,
+            internalType: 'int224',
+            name: 'value',
+            type: 'int224',
+          },
+          {
+            indexed: false,
+            internalType: 'uint32',
+            name: 'timestamp',
+            type: 'uint32',
+          },
+        ],
+        name: 'UpdatedBeaconSetWithBeacons',
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'beaconId',
+            type: 'bytes32',
+          },
+          {
+            indexed: false,
+            internalType: 'int224',
+            name: 'value',
+            type: 'int224',
+          },
+          {
+            indexed: false,
+            internalType: 'uint32',
+            name: 'timestamp',
+            type: 'uint32',
+          },
+        ],
+        name: 'UpdatedBeaconWithSignedData',
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'beaconSetId',
+            type: 'bytes32',
+          },
+          {
+            indexed: true,
+            internalType: 'address',
+            name: 'proxy',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'updateId',
+            type: 'bytes32',
+          },
+          {
+            indexed: false,
+            internalType: 'int224',
+            name: 'value',
+            type: 'int224',
+          },
+          {
+            indexed: false,
+            internalType: 'uint32',
+            name: 'timestamp',
+            type: 'uint32',
+          },
+        ],
+        name: 'UpdatedOevProxyBeaconSetWithSignedData',
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'beaconId',
+            type: 'bytes32',
+          },
+          {
+            indexed: true,
+            internalType: 'address',
+            name: 'proxy',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'updateId',
+            type: 'bytes32',
+          },
+          {
+            indexed: false,
+            internalType: 'int224',
+            name: 'value',
+            type: 'int224',
+          },
+          {
+            indexed: false,
+            internalType: 'uint32',
+            name: 'timestamp',
+            type: 'uint32',
+          },
+        ],
+        name: 'UpdatedOevProxyBeaconWithSignedData',
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: 'address',
+            name: 'oevProxy',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            internalType: 'address',
+            name: 'oevBeneficiary',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+        ],
+        name: 'Withdrew',
+        type: 'event',
+      },
+      {
+        inputs: [],
+        name: 'DAPI_NAME_SETTER_ROLE_DESCRIPTION',
+        outputs: [
+          {
+            internalType: 'string',
+            name: '',
+            type: 'string',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'accessControlRegistry',
+        outputs: [
+          {
+            internalType: 'address',
+            name: '',
+            type: 'address',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'adminRole',
+        outputs: [
+          {
+            internalType: 'bytes32',
+            name: '',
+            type: 'bytes32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'adminRoleDescription',
+        outputs: [
+          {
+            internalType: 'string',
+            name: '',
+            type: 'string',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'address',
+            name: 'account',
+            type: 'address',
+          },
+        ],
+        name: 'containsBytecode',
+        outputs: [
+          {
+            internalType: 'bool',
+            name: '',
+            type: 'bool',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dapiNameHash',
+            type: 'bytes32',
+          },
+        ],
+        name: 'dapiNameHashToDataFeedId',
+        outputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'dapiNameSetterRole',
+        outputs: [
+          {
+            internalType: 'bytes32',
+            name: '',
+            type: 'bytes32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dapiName',
+            type: 'bytes32',
+          },
+        ],
+        name: 'dapiNameToDataFeedId',
+        outputs: [
+          {
+            internalType: 'bytes32',
+            name: '',
+            type: 'bytes32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+        ],
+        name: 'dataFeeds',
+        outputs: [
+          {
+            internalType: 'int224',
+            name: 'value',
+            type: 'int224',
+          },
+          {
+            internalType: 'uint32',
+            name: 'timestamp',
+            type: 'uint32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'address',
+            name: 'account',
+            type: 'address',
+          },
+        ],
+        name: 'getBalance',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'getBlockBasefee',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'getBlockNumber',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'getBlockTimestamp',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'getChainId',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'manager',
+        outputs: [
+          {
+            internalType: 'address',
+            name: '',
+            type: 'address',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes[]',
+            name: 'data',
+            type: 'bytes[]',
+          },
+        ],
+        name: 'multicall',
+        outputs: [
+          {
+            internalType: 'bytes[]',
+            name: 'returndata',
+            type: 'bytes[]',
+          },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'address',
+            name: 'oevProxy',
+            type: 'address',
+          },
+        ],
+        name: 'oevProxyToBalance',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: 'balance',
+            type: 'uint256',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'address',
+            name: 'proxy',
+            type: 'address',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+        ],
+        name: 'oevProxyToIdToDataFeed',
+        outputs: [
+          {
+            internalType: 'int224',
+            name: 'value',
+            type: 'int224',
+          },
+          {
+            internalType: 'uint32',
+            name: 'timestamp',
+            type: 'uint32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dapiNameHash',
+            type: 'bytes32',
+          },
+        ],
+        name: 'readDataFeedWithDapiNameHash',
+        outputs: [
+          {
+            internalType: 'int224',
+            name: 'value',
+            type: 'int224',
+          },
+          {
+            internalType: 'uint32',
+            name: 'timestamp',
+            type: 'uint32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dapiNameHash',
+            type: 'bytes32',
+          },
+        ],
+        name: 'readDataFeedWithDapiNameHashAsOevProxy',
+        outputs: [
+          {
+            internalType: 'int224',
+            name: 'value',
+            type: 'int224',
+          },
+          {
+            internalType: 'uint32',
+            name: 'timestamp',
+            type: 'uint32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+        ],
+        name: 'readDataFeedWithId',
+        outputs: [
+          {
+            internalType: 'int224',
+            name: 'value',
+            type: 'int224',
+          },
+          {
+            internalType: 'uint32',
+            name: 'timestamp',
+            type: 'uint32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+        ],
+        name: 'readDataFeedWithIdAsOevProxy',
+        outputs: [
+          {
+            internalType: 'int224',
+            name: 'value',
+            type: 'int224',
+          },
+          {
+            internalType: 'uint32',
+            name: 'timestamp',
+            type: 'uint32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dapiName',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+        ],
+        name: 'setDapiName',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes[]',
+            name: 'data',
+            type: 'bytes[]',
+          },
+        ],
+        name: 'tryMulticall',
+        outputs: [
+          {
+            internalType: 'bool[]',
+            name: 'successes',
+            type: 'bool[]',
+          },
+          {
+            internalType: 'bytes[]',
+            name: 'returndata',
+            type: 'bytes[]',
+          },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32[]',
+            name: 'beaconIds',
+            type: 'bytes32[]',
+          },
+        ],
+        name: 'updateBeaconSetWithBeacons',
+        outputs: [
+          {
+            internalType: 'bytes32',
+            name: 'beaconSetId',
+            type: 'bytes32',
+          },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'address',
+            name: 'airnode',
+            type: 'address',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'templateId',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'uint256',
+            name: 'timestamp',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes',
+            name: 'data',
+            type: 'bytes',
+          },
+          {
+            internalType: 'bytes',
+            name: 'signature',
+            type: 'bytes',
+          },
+        ],
+        name: 'updateBeaconWithSignedData',
+        outputs: [
+          {
+            internalType: 'bytes32',
+            name: 'beaconId',
+            type: 'bytes32',
+          },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'address',
+            name: 'oevProxy',
+            type: 'address',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'updateId',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'uint256',
+            name: 'timestamp',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes',
+            name: 'data',
+            type: 'bytes',
+          },
+          {
+            internalType: 'bytes[]',
+            name: 'packedOevUpdateSignatures',
+            type: 'bytes[]',
+          },
+        ],
+        name: 'updateOevProxyDataFeedWithSignedData',
+        outputs: [],
+        stateMutability: 'payable',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'address',
+            name: 'oevProxy',
+            type: 'address',
+          },
+        ],
+        name: 'withdraw',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+    ];
+    const dapiDataRegistryAbi = [
+      {
+        inputs: [
+          {
+            internalType: 'address',
+            name: '_accessControlRegistry',
+            type: 'address',
+          },
+          {
+            internalType: 'string',
+            name: '_adminRoleDescription',
+            type: 'string',
+          },
+          {
+            internalType: 'address',
+            name: '_manager',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: '_hashRegistry',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: '_api3ServerV1',
+            type: 'address',
+          },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'constructor',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'dapiName',
+            type: 'bytes32',
+          },
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+          {
+            indexed: false,
+            internalType: 'address',
+            name: 'sponsorWallet',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            internalType: 'uint256',
+            name: 'deviationThresholdInPercentage',
+            type: 'uint256',
+          },
+          {
+            indexed: false,
+            internalType: 'int224',
+            name: 'deviationReference',
+            type: 'int224',
+          },
+          {
+            indexed: false,
+            internalType: 'uint32',
+            name: 'heartbeatInterval',
+            type: 'uint32',
+          },
+        ],
+        name: 'AddedDapi',
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+          {
+            indexed: false,
+            internalType: 'bytes',
+            name: 'dataFeedData',
+            type: 'bytes',
+          },
+        ],
+        name: 'RegisteredDataFeed',
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: 'address',
+            name: 'airnode',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            internalType: 'string',
+            name: 'url',
+            type: 'string',
+          },
+        ],
+        name: 'RegisteredSignedApiUrl',
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'dapiName',
+            type: 'bytes32',
+          },
+          {
+            indexed: false,
+            internalType: 'address',
+            name: 'sender',
+            type: 'address',
+          },
+        ],
+        name: 'RemovedDapi',
+        type: 'event',
+      },
+      {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'dapiName',
+            type: 'bytes32',
+          },
+          {
+            indexed: true,
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+          {
+            indexed: false,
+            internalType: 'address',
+            name: 'sponsorWallet',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            internalType: 'address',
+            name: 'sender',
+            type: 'address',
+          },
+        ],
+        name: 'UpdatedDapiDataFeedId',
+        type: 'event',
+      },
+      {
+        inputs: [],
+        name: 'DAPI_ADDER_ROLE_DESCRIPTION',
+        outputs: [
+          {
+            internalType: 'string',
+            name: '',
+            type: 'string',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'DAPI_REMOVER_ROLE_DESCRIPTION',
+        outputs: [
+          {
+            internalType: 'string',
+            name: '',
+            type: 'string',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'HUNDRED_PERCENT',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'accessControlRegistry',
+        outputs: [
+          {
+            internalType: 'address',
+            name: '',
+            type: 'address',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dapiName',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'address',
+            name: 'sponsorWallet',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'deviationThresholdInPercentage',
+            type: 'uint256',
+          },
+          {
+            internalType: 'int224',
+            name: 'deviationReference',
+            type: 'int224',
+          },
+          {
+            internalType: 'uint32',
+            name: 'heartbeatInterval',
+            type: 'uint32',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'root',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]',
+          },
+        ],
+        name: 'addDapi',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'adminRole',
+        outputs: [
+          {
+            internalType: 'bytes32',
+            name: '',
+            type: 'bytes32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'adminRoleDescription',
+        outputs: [
+          {
+            internalType: 'string',
+            name: '',
+            type: 'string',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'address',
+            name: '',
+            type: 'address',
+          },
+        ],
+        name: 'airnodeToSignedApiUrl',
+        outputs: [
+          {
+            internalType: 'string',
+            name: '',
+            type: 'string',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'api3ServerV1',
+        outputs: [
+          {
+            internalType: 'address',
+            name: '',
+            type: 'address',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'dapiAdderRole',
+        outputs: [
+          {
+            internalType: 'bytes32',
+            name: '',
+            type: 'bytes32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: '',
+            type: 'bytes32',
+          },
+        ],
+        name: 'dapiNameToUpdateParameters',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: 'deviationThresholdInPercentage',
+            type: 'uint256',
+          },
+          {
+            internalType: 'int224',
+            name: 'deviationReference',
+            type: 'int224',
+          },
+          {
+            internalType: 'uint32',
+            name: 'heartbeatInterval',
+            type: 'uint32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'dapiRemoverRole',
+        outputs: [
+          {
+            internalType: 'bytes32',
+            name: '',
+            type: 'bytes32',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'dapisCount',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: 'count',
+            type: 'uint256',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: '',
+            type: 'bytes32',
+          },
+        ],
+        name: 'dataFeeds',
+        outputs: [
+          {
+            internalType: 'bytes',
+            name: '',
+            type: 'bytes',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'hashRegistry',
+        outputs: [
+          {
+            internalType: 'address',
+            name: '',
+            type: 'address',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'manager',
+        outputs: [
+          {
+            internalType: 'address',
+            name: '',
+            type: 'address',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes[]',
+            name: 'data',
+            type: 'bytes[]',
+          },
+        ],
+        name: 'multicall',
+        outputs: [
+          {
+            internalType: 'bytes[]',
+            name: 'returndata',
+            type: 'bytes[]',
+          },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'uint256',
+            name: 'index',
+            type: 'uint256',
+          },
+        ],
+        name: 'readDapiWithIndex',
+        outputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dapiName',
+            type: 'bytes32',
+          },
+          {
+            components: [
+              {
+                internalType: 'uint256',
+                name: 'deviationThresholdInPercentage',
+                type: 'uint256',
+              },
+              {
+                internalType: 'int224',
+                name: 'deviationReference',
+                type: 'int224',
+              },
+              {
+                internalType: 'uint32',
+                name: 'heartbeatInterval',
+                type: 'uint32',
+              },
+            ],
+            internalType: 'struct IDapiDataRegistry.UpdateParameters',
+            name: 'updateParameters',
+            type: 'tuple',
+          },
+          {
+            components: [
+              {
+                internalType: 'int224',
+                name: 'value',
+                type: 'int224',
+              },
+              {
+                internalType: 'uint32',
+                name: 'timestamp',
+                type: 'uint32',
+              },
+            ],
+            internalType: 'struct IDapiDataRegistry.DataFeedValue',
+            name: 'dataFeedValue',
+            type: 'tuple',
+          },
+          {
+            internalType: 'bytes',
+            name: 'dataFeed',
+            type: 'bytes',
+          },
+          {
+            internalType: 'string[]',
+            name: 'signedApiUrls',
+            type: 'string[]',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dapiName',
+            type: 'bytes32',
+          },
+        ],
+        name: 'readDapiWithName',
+        outputs: [
+          {
+            components: [
+              {
+                internalType: 'uint256',
+                name: 'deviationThresholdInPercentage',
+                type: 'uint256',
+              },
+              {
+                internalType: 'int224',
+                name: 'deviationReference',
+                type: 'int224',
+              },
+              {
+                internalType: 'uint32',
+                name: 'heartbeatInterval',
+                type: 'uint32',
+              },
+            ],
+            internalType: 'struct IDapiDataRegistry.UpdateParameters',
+            name: 'updateParameters',
+            type: 'tuple',
+          },
+          {
+            components: [
+              {
+                internalType: 'int224',
+                name: 'value',
+                type: 'int224',
+              },
+              {
+                internalType: 'uint32',
+                name: 'timestamp',
+                type: 'uint32',
+              },
+            ],
+            internalType: 'struct IDapiDataRegistry.DataFeedValue',
+            name: 'dataFeedValue',
+            type: 'tuple',
+          },
+          {
+            internalType: 'bytes',
+            name: 'dataFeed',
+            type: 'bytes',
+          },
+          {
+            internalType: 'string[]',
+            name: 'signedApiUrls',
+            type: 'string[]',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'address',
+            name: 'airnode',
+            type: 'address',
+          },
+          {
+            internalType: 'string',
+            name: 'url',
+            type: 'string',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'root',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]',
+          },
+        ],
+        name: 'registerAirnodeSignedApiUrl',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes',
+            name: 'dataFeed',
+            type: 'bytes',
+          },
+        ],
+        name: 'registerDataFeed',
+        outputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dapiName',
+            type: 'bytes32',
+          },
+        ],
+        name: 'removeDapi',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes[]',
+            name: 'data',
+            type: 'bytes[]',
+          },
+        ],
+        name: 'tryMulticall',
+        outputs: [
+          {
+            internalType: 'bool[]',
+            name: 'successes',
+            type: 'bool[]',
+          },
+          {
+            internalType: 'bytes[]',
+            name: 'returndata',
+            type: 'bytes[]',
+          },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'dapiName',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'dataFeedId',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'address',
+            name: 'sponsorWallet',
+            type: 'address',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'root',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]',
+          },
+        ],
+        name: 'updateDapiDataFeedId',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+    ];
+
+    // Configuration
+    const urlParams = new URLSearchParams(window.location.search);
+    const rpcUrl = 'http://127.0.0.1:8545',
+      api3ServerV1Address = urlParams.get('api3ServerV1Address'),
+      dapiDataRegistryAddress = urlParams.get('dapiDataRegistryAddress');
+
+    if (!api3ServerV1Address) throw new Error('api3ServerV1Address must be provided as URL parameter');
+    if (!dapiDataRegistryAddress) throw new Error('dapiDataRegistryAddress must be provided as URL parameter');
+
+    function deriveBeaconId(airnodeAddress, templateId) {
+      return ethers.utils.solidityKeccak256(['address', 'bytes32'], [airnodeAddress, templateId]);
+    }
+
+    function deriveBeaconSetId(beaconIds) {
+      return ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [beaconIds]));
+    }
+
+    const decodeDataFeed = (dataFeed) => {
+      if (dataFeed.length === 130) {
+        // (64 [actual bytes] * 2[hex encoding] ) + 2 [for the '0x' preamble]
+        // This is a hex encoded string, the contract works with bytes directly
+        const [airnodeAddress, templateId] = ethers.utils.defaultAbiCoder.decode(['address', 'bytes32'], dataFeed);
+
+        const dataFeedId = deriveBeaconId(airnodeAddress, templateId);
+
+        return { dataFeedId, beacons: [{ beaconId: dataFeedId, airnodeAddress, templateId }] };
+      }
+
+      const [airnodeAddresses, templateIds] = ethers.utils.defaultAbiCoder.decode(['address[]', 'bytes32[]'], dataFeed);
+
+      const beacons = airnodeAddresses.map((airnodeAddress, idx) => {
+        const templateId = templateIds[idx];
+        const beaconId = deriveBeaconId(airnodeAddress, templateId);
+
+        return { beaconId, airnodeAddress, templateId };
+      });
+
+      const dataFeedId = deriveBeaconSetId(beacons.map((b) => b.beaconId));
+
+      return { dataFeedId, beacons };
+    };
+
+    const calculateMedian = (arr) => {
+      if (arr.length === 0) throw new Error('Cannot calculate median of empty array');
+      const mid = Math.floor(arr.length / 2);
+
+      const nums = [...arr].sort((a, b) => {
+        if (a.lt(b)) return -1;
+        else if (a.gt(b)) return 1;
+        else return 0;
+      });
+
+      return arr.length % 2 === 0 ? nums[mid - 1].add(nums[mid]).div(2) : nums[mid];
+    };
+
+    const decodeBeaconValue = (encodedBeaconValue) => {
+      // Solidity type(int224).min
+      const INT224_MIN = ethers.BigNumber.from(2).pow(ethers.BigNumber.from(223)).mul(ethers.BigNumber.from(-1));
+      // Solidity type(int224).max
+      const INT224_MAX = ethers.BigNumber.from(2).pow(ethers.BigNumber.from(223)).sub(ethers.BigNumber.from(1));
+
+      const decodedBeaconValue = ethers.BigNumber.from(
+        ethers.utils.defaultAbiCoder.decode(['int256'], encodedBeaconValue)[0]
+      );
+      if (decodedBeaconValue.gt(INT224_MAX) || decodedBeaconValue.lt(INT224_MIN)) {
+        return null;
+      }
+
+      return decodedBeaconValue;
+    };
+
+    const calculateUpdateInPercentage = (initialValue, updatedValue) => {
+      const delta = updatedValue.sub(initialValue);
+      const absoluteDelta = delta.abs();
+
+      // Avoid division by 0
+      const absoluteInitialValue = initialValue.isZero() ? ethers.BigNumber.from(1) : initialValue.abs();
+
+      return absoluteDelta.mul(ethers.BigNumber.from(1e8)).div(absoluteInitialValue);
+    };
+
+    const checkDeviationThresholdExceeded = (onChainValue, deviationThreshold, apiValue) => {
+      const updateInPercentage = calculateUpdateInPercentage(onChainValue, apiValue);
+
+      return updateInPercentage.gt(deviationThreshold);
+    };
+
+    setInterval(async () => {
+      const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+      const dapiDataRegistry = new ethers.Contract(dapiDataRegistryAddress, dapiDataRegistryAbi, provider);
+      const activeDapisCount = await dapiDataRegistry.dapisCount();
+
+      document.getElementById('activeDapisCount').innerHTML = activeDapisCount;
+      let newActiveDapisHtml = '';
+      for (let i = 0; i < activeDapisCount; i++) {
+        const { dapiName, updateParameters, dataFeedValue, dataFeed, signedApiUrls } =
+          await dapiDataRegistry.readDapiWithIndex(i);
+        const { deviationReference, deviationThresholdInPercentage, heartbeatInterval } = updateParameters;
+        const { value, timestamp } = dataFeedValue;
+        const dapi = {
+          dapiName,
+          updateParameters: {
+            deviationReference: deviationReference.toString(),
+            deviationThresholdInPercentage: deviationThresholdInPercentage.toString(),
+            heartbeatInterval: heartbeatInterval,
+          },
+          dataFeedValue: { value: value.toString(), timestamp },
+          decodedDataFeed: decodeDataFeed(dataFeed),
+          signedApiUrls,
+        };
+        console.log('Dapi', dapi); // For debugging purposes.
+
+        let signedDatas = [];
+        for (let i = 0; i < signedApiUrls.length; i++) {
+          const url = signedApiUrls[i];
+          const airnode = dapi.decodedDataFeed.beacons[i].airnodeAddress;
+          const signedApiResponse = await fetch(`${url.replace('host.docker.internal', 'localhost')}/${airnode}`).then(
+            (res) => res.json()
+          );
+          const signedData = signedApiResponse.data[dapi.decodedDataFeed.beacons[i].beaconId];
+          signedDatas.push({ ...signedData, value: decodeBeaconValue(signedData.encodedValue).toString() });
+        }
+        console.log('Signed datas', signedDatas); // For debugging purposes.
+
+        const newBeaconSetValue = calculateMedian(
+          signedDatas.map((signedData) => ethers.BigNumber.from(signedData.value))
+        );
+        const newBeaconSetTimestamp = calculateMedian(
+          signedDatas.map((signedData) => ethers.BigNumber.from(signedData.timestamp))
+        ).toNumber();
+
+        const deviationPercentage = calculateUpdateInPercentage(value, newBeaconSetValue).toNumber() / 1e6;
+        const deviationThresholdPercentage = deviationThresholdInPercentage.toNumber() / 1e6;
+
+        const dapiInfo = {
+          dapiName: dapiName,
+          decodedDapiName: ethers.utils.parseBytes32String(dapiName),
+          dataFeedValue: dapi.dataFeedValue,
+          offChainValue: {
+            value: newBeaconSetValue.toString(),
+            timestamp: newBeaconSetTimestamp,
+          },
+          deviationPercentage:
+            deviationPercentage > deviationThresholdPercentage ? `<b>${deviationPercentage}</b>` : deviationPercentage,
+          deviationThresholdPercentage: deviationThresholdPercentage,
+        };
+
+        newActiveDapisHtml += JSON.stringify(dapiInfo, null, 2) + '\n\n';
+      }
+      document.getElementById('activeDapis').innerHTML = newActiveDapisHtml;
+    }, 1000);
+  </script>
+</html>

--- a/local-test-configuration/pusher-1/.env.example
+++ b/local-test-configuration/pusher-1/.env.example
@@ -1,0 +1,4 @@
+LOGGER_ENABLED=true
+LOG_COLORIZE=true
+LOG_FORMAT=pretty
+LOG_LEVEL=debug

--- a/local-test-configuration/pusher-1/pusher.json
+++ b/local-test-configuration/pusher-1/pusher.json
@@ -1,0 +1,100 @@
+{
+  "templates": {
+    "0xa5419706d8edb3bbafad83fe2b4e7dc851de5e4cd9529f9f27bb393016c81ae5": {
+      "endpointId": "0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc",
+      "parameters": [{ "type": "string32", "name": "name", "value": "NEAR/USD" }]
+    },
+    "0x8f255387c5fdb03117d82372b8fa5c7813881fd9a8202b7cc373f1a5868496b2": {
+      "endpointId": "0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc",
+      "parameters": [{ "type": "string32", "name": "name", "value": "AAVE/USD" }]
+    },
+    "0x89bbdb4e2d7510abf1ca0ed53295e31c00a6939fc12e77d67bf3a4cb3c31f61c": {
+      "endpointId": "0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc",
+      "parameters": [{ "type": "string32", "name": "name", "value": "MATIC/USD" }]
+    }
+  },
+  "endpoints": {
+    "0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc": {
+      "endpointName": "feed",
+      "oisTitle": "Nodary"
+    }
+  },
+  "triggers": {
+    "signedApiUpdates": [
+      {
+        "signedApiName": "localhost",
+        "templateIds": [
+          "0xa5419706d8edb3bbafad83fe2b4e7dc851de5e4cd9529f9f27bb393016c81ae5",
+          "0x8f255387c5fdb03117d82372b8fa5c7813881fd9a8202b7cc373f1a5868496b2",
+          "0x89bbdb4e2d7510abf1ca0ed53295e31c00a6939fc12e77d67bf3a4cb3c31f61c"
+        ],
+        "fetchInterval": 10,
+        "updateDelay": 0
+      }
+    ]
+  },
+  "signedApis": [
+    {
+      "name": "localhost",
+      "url": "http://${LOCALHOST_IP}:4001"
+    }
+  ],
+  "ois": [
+    {
+      "oisFormat": "2.2.0",
+      "title": "Nodary",
+      "version": "0.2.0",
+      "apiSpecifications": {
+        "components": {
+          "securitySchemes": {
+            "NodarySecurityScheme1ApiKey": { "in": "header", "name": "x-nodary-api-key", "type": "apiKey" }
+          }
+        },
+        "paths": {
+          "/feed/latest": { "get": { "parameters": [{ "in": "query", "name": "name" }] } },
+          "/feed/latestV2": { "get": { "parameters": [{ "in": "query", "name": "names" }] } }
+        },
+        "servers": [{ "url": "https://api.nodary.io" }],
+        "security": { "NodarySecurityScheme1ApiKey": [] }
+      },
+      "endpoints": [
+        {
+          "fixedOperationParameters": [],
+          "name": "feed",
+          "operation": { "method": "get", "path": "/feed/latestV2" },
+          "parameters": [{ "name": "name", "operationParameter": { "in": "query", "name": "names" } }],
+          "reservedParameters": [
+            { "name": "_type", "fixed": "int256" },
+            { "name": "_times", "fixed": "1000000000000000000" }
+          ],
+          "preProcessingSpecifications": [
+            {
+              "environment": "Node",
+              "value": "const output = {};",
+              "timeoutMs": 5000
+            }
+          ],
+          "postProcessingSpecifications": [
+            {
+              "environment": "Node",
+              "value": "const output = input[endpointParameters.name].value;",
+              "timeoutMs": 5000
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "apiCredentials": [
+    {
+      "oisTitle": "Nodary",
+      "securitySchemeName": "NodarySecurityScheme1ApiKey",
+      "securitySchemeValue": "${NODARY_API_KEY}"
+    }
+  ],
+  "nodeSettings": {
+    "nodeVersion": "0.1.0",
+    "airnodeWalletMnemonic": "${AIRNODE_WALLET_MNEMONIC}",
+    "stage": "local-example"
+  }
+}

--- a/local-test-configuration/pusher-1/secrets.example.env
+++ b/local-test-configuration/pusher-1/secrets.example.env
@@ -1,0 +1,9 @@
+# Secrets must NOT be quoted.
+
+# We use a fixed (static) wallet mnemonic for simplicity. Signed API (1) is configured to only allow pushes from this
+# Airnode.
+AIRNODE_WALLET_MNEMONIC=artwork head deal walnut online memory okay ring tower doll cube fix
+# NOTE: Ask for this privately if you don't have and want to run this.
+NODARY_API_KEY=
+# NOTE: Use "host.docker.internal" if using Docker for Desktop.
+LOCALHOST_IP=localhost

--- a/local-test-configuration/pusher-2/.env.example
+++ b/local-test-configuration/pusher-2/.env.example
@@ -1,0 +1,4 @@
+LOGGER_ENABLED=true
+LOG_COLORIZE=true
+LOG_FORMAT=pretty
+LOG_LEVEL=debug

--- a/local-test-configuration/pusher-2/pusher.json
+++ b/local-test-configuration/pusher-2/pusher.json
@@ -1,0 +1,100 @@
+{
+  "templates": {
+    "0xa5419706d8edb3bbafad83fe2b4e7dc851de5e4cd9529f9f27bb393016c81ae5": {
+      "endpointId": "0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc",
+      "parameters": [{ "type": "string32", "name": "name", "value": "NEAR/USD" }]
+    },
+    "0x8f255387c5fdb03117d82372b8fa5c7813881fd9a8202b7cc373f1a5868496b2": {
+      "endpointId": "0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc",
+      "parameters": [{ "type": "string32", "name": "name", "value": "AAVE/USD" }]
+    },
+    "0x89bbdb4e2d7510abf1ca0ed53295e31c00a6939fc12e77d67bf3a4cb3c31f61c": {
+      "endpointId": "0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc",
+      "parameters": [{ "type": "string32", "name": "name", "value": "MATIC/USD" }]
+    }
+  },
+  "endpoints": {
+    "0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc": {
+      "endpointName": "feed",
+      "oisTitle": "Nodary"
+    }
+  },
+  "triggers": {
+    "signedApiUpdates": [
+      {
+        "signedApiName": "localhost",
+        "templateIds": [
+          "0xa5419706d8edb3bbafad83fe2b4e7dc851de5e4cd9529f9f27bb393016c81ae5",
+          "0x8f255387c5fdb03117d82372b8fa5c7813881fd9a8202b7cc373f1a5868496b2",
+          "0x89bbdb4e2d7510abf1ca0ed53295e31c00a6939fc12e77d67bf3a4cb3c31f61c"
+        ],
+        "fetchInterval": 20,
+        "updateDelay": 60
+      }
+    ]
+  },
+  "signedApis": [
+    {
+      "name": "localhost",
+      "url": "http://${LOCALHOST_IP}:4002"
+    }
+  ],
+  "ois": [
+    {
+      "oisFormat": "2.2.0",
+      "title": "Nodary",
+      "version": "0.2.0",
+      "apiSpecifications": {
+        "components": {
+          "securitySchemes": {
+            "NodarySecurityScheme1ApiKey": { "in": "header", "name": "x-nodary-api-key", "type": "apiKey" }
+          }
+        },
+        "paths": {
+          "/feed/latest": { "get": { "parameters": [{ "in": "query", "name": "name" }] } },
+          "/feed/latestV2": { "get": { "parameters": [{ "in": "query", "name": "names" }] } }
+        },
+        "servers": [{ "url": "https://api.nodary.io" }],
+        "security": { "NodarySecurityScheme1ApiKey": [] }
+      },
+      "endpoints": [
+        {
+          "fixedOperationParameters": [],
+          "name": "feed",
+          "operation": { "method": "get", "path": "/feed/latestV2" },
+          "parameters": [{ "name": "name", "operationParameter": { "in": "query", "name": "names" } }],
+          "reservedParameters": [
+            { "name": "_type", "fixed": "int256" },
+            { "name": "_times", "fixed": "1000000000000000000" }
+          ],
+          "preProcessingSpecifications": [
+            {
+              "environment": "Node",
+              "value": "const output = {};",
+              "timeoutMs": 5000
+            }
+          ],
+          "postProcessingSpecifications": [
+            {
+              "environment": "Node",
+              "value": "const output = input[endpointParameters.name].value;",
+              "timeoutMs": 5000
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "apiCredentials": [
+    {
+      "oisTitle": "Nodary",
+      "securitySchemeName": "NodarySecurityScheme1ApiKey",
+      "securitySchemeValue": "${NODARY_API_KEY}"
+    }
+  ],
+  "nodeSettings": {
+    "nodeVersion": "0.1.0",
+    "airnodeWalletMnemonic": "${AIRNODE_WALLET_MNEMONIC}",
+    "stage": "local-example"
+  }
+}

--- a/local-test-configuration/pusher-2/secrets.example.env
+++ b/local-test-configuration/pusher-2/secrets.example.env
@@ -1,0 +1,9 @@
+# Secrets must NOT be quoted.
+
+# We use a fixed (static) wallet mnemonic for simplicity. Signed API (2) is configured to only allow pushes from this
+# Airnode.
+AIRNODE_WALLET_MNEMONIC=age sibling rookie exact leaf feed you tonight book profit hello kidney
+# NOTE: Ask for this privately if you don't have and want to run this.
+NODARY_API_KEY=
+# NOTE: Use "host.docker.internal" if using Docker for Desktop.
+LOCALHOST_IP=localhost

--- a/local-test-configuration/scripts/.env.example
+++ b/local-test-configuration/scripts/.env.example
@@ -1,0 +1,3 @@
+# The wallet with funds to sponsor the dAPI sponsor wallets and deploy necessary contracts.
+FUNDER_MNEMONIC=test test test test test test test test test test test junk
+PROVIDER_URL=http://127.0.0.1:8545/

--- a/local-test-configuration/scripts/initialize-chain.ts
+++ b/local-test-configuration/scripts/initialize-chain.ts
@@ -1,0 +1,293 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import * as abi from '@api3/airnode-abi';
+import {
+  AccessControlRegistry__factory as AccessControlRegistryFactory,
+  Api3ServerV1__factory as Api3ServerV1Factory,
+} from '@api3/airnode-protocol-v1';
+import { StandardMerkleTree } from '@openzeppelin/merkle-tree';
+import dotenv from 'dotenv';
+import type { Signer } from 'ethers';
+import { ethers } from 'ethers';
+import { zip } from 'lodash';
+
+import { interpolateSecrets, parseSecrets } from '../../src/config/utils';
+import {
+  DapiDataRegistry__factory as DapiDataRegistryFactory,
+  HashRegistry__factory as HashRegistryFactory,
+} from '../../src/typechain-types';
+import { deriveBeaconId, deriveSponsorWallet } from '../../src/utils';
+
+interface RawBeaconData {
+  airnodeAddress: string;
+  endpointId: string;
+  parameters: {
+    type: string;
+    name: string;
+    value: string;
+  }[];
+}
+
+const deriveBeaconData = (beaconData: RawBeaconData) => {
+  const { endpointId, parameters: parameters, airnodeAddress } = beaconData;
+
+  const encodedParameters = abi.encode(parameters);
+  const templateId = ethers.utils.solidityKeccak256(['bytes32', 'bytes'], [endpointId, encodedParameters]);
+  const beaconId = deriveBeaconId(airnodeAddress, templateId)!;
+
+  return { endpointId, templateId, encodedParameters, beaconId, parameters, airnodeAddress };
+};
+
+export const deriveRootRole = (managerAddress: string) => {
+  return ethers.utils.solidityKeccak256(['address'], [managerAddress]);
+};
+
+export const deriveRole = (adminRole: string, roleDescription: string) => {
+  return ethers.utils.solidityKeccak256(
+    ['bytes32', 'bytes32'],
+    [adminRole, ethers.utils.solidityKeccak256(['string'], [roleDescription])]
+  );
+};
+
+const loadPusherConfig = (pusherDir: 'pusher-1' | 'pusher-2') => {
+  const configPath = join(__dirname, `/../`, pusherDir);
+  const rawConfig = JSON.parse(readFileSync(join(configPath, 'pusher.json'), 'utf8'));
+  const rawSecrets = dotenv.parse(readFileSync(join(configPath, 'secrets.env'), 'utf8'));
+
+  const secrets = parseSecrets(rawSecrets);
+  return interpolateSecrets(rawConfig, secrets);
+};
+
+export const fundAirseekerSponsorWallet = async (
+  funderWallet: ethers.Wallet,
+  { beaconSetNames }: { beaconSetNames: string[] }
+) => {
+  const airseekerSecrets = dotenv.parse(readFileSync(join(__dirname, `/../airseeker`, 'secrets.env'), 'utf8'));
+  const airseekerWalletMnemonic = airseekerSecrets.SPONSOR_WALLET_MNEMONIC;
+  if (!airseekerWalletMnemonic) throw new Error('SPONSOR_WALLET_MNEMONIC not found in Airseeker secrets');
+
+  // Initialize sponsor wallets
+  for (const beaconSetName of beaconSetNames) {
+    const dapiName = ethers.utils.formatBytes32String(beaconSetName);
+
+    const sponsor1Wallet = deriveSponsorWallet(airseekerWalletMnemonic, dapiName);
+    await funderWallet.sendTransaction({
+      to: sponsor1Wallet.address,
+      value: ethers.utils.parseEther('1'),
+    });
+
+    console.info(`Funding sponsor wallets`, {
+      dapiName,
+      sponsor1WalletAddress: sponsor1Wallet.address,
+    });
+  }
+};
+
+export const deploy = async (funderWallet: ethers.Wallet, provider: ethers.providers.JsonRpcProvider) => {
+  // NOTE: It is OK if all of these roles are done via the funder wallet.
+  const deployer = funderWallet,
+    manager = funderWallet,
+    registryOwner = funderWallet,
+    api3MarketContract = funderWallet,
+    rootSigner1 = funderWallet,
+    randomPerson = funderWallet,
+    walletFunder = funderWallet;
+
+  // Deploy contracts
+  const accessControlRegistryFactory = new AccessControlRegistryFactory(deployer as Signer);
+  const accessControlRegistry = await accessControlRegistryFactory.deploy();
+  const api3ServerV1Factory = new Api3ServerV1Factory(deployer as Signer);
+  const api3ServerV1AdminRoleDescription = 'Api3ServerV1 admin';
+  const api3ServerV1 = await api3ServerV1Factory.deploy(
+    accessControlRegistry.address,
+    api3ServerV1AdminRoleDescription,
+    manager.address
+  );
+  const hashRegistryFactory = new HashRegistryFactory(deployer as Signer);
+  const hashRegistry = await hashRegistryFactory.deploy();
+  await hashRegistry.connect(deployer).transferOwnership(registryOwner.address);
+  const dapiDataRegistryFactory = new DapiDataRegistryFactory(deployer as Signer);
+  const dapiDataRegistryAdminRoleDescription = 'DapiDataRegistry admin';
+  const dapiDataRegistry = await dapiDataRegistryFactory.deploy(
+    accessControlRegistry.address,
+    dapiDataRegistryAdminRoleDescription,
+    manager.address,
+    hashRegistry.address,
+    api3ServerV1.address
+  );
+
+  // Set up roles
+  const rootRole = deriveRootRole(manager.address);
+  const dapiDataRegistryAdminRole = deriveRole(rootRole, dapiDataRegistryAdminRoleDescription);
+  const dapiAdderRoleDescription = await dapiDataRegistry.DAPI_ADDER_ROLE_DESCRIPTION();
+  const dapiAdderRole = deriveRole(dapiDataRegistryAdminRole, dapiAdderRoleDescription);
+  const dapiRemoverRoleDescription = await dapiDataRegistry.DAPI_REMOVER_ROLE_DESCRIPTION();
+  await accessControlRegistry
+    .connect(manager)
+    .initializeRoleAndGrantToSender(rootRole, dapiDataRegistryAdminRoleDescription);
+  await accessControlRegistry
+    .connect(manager)
+    .initializeRoleAndGrantToSender(dapiDataRegistryAdminRole, dapiAdderRoleDescription);
+  await accessControlRegistry
+    .connect(manager)
+    .initializeRoleAndGrantToSender(dapiDataRegistryAdminRole, dapiRemoverRoleDescription);
+  await accessControlRegistry.connect(manager).grantRole(dapiAdderRole, api3MarketContract.address);
+  await accessControlRegistry
+    .connect(manager)
+    .initializeRoleAndGrantToSender(rootRole, api3ServerV1AdminRoleDescription);
+  await accessControlRegistry
+    .connect(manager)
+    .initializeRoleAndGrantToSender(
+      await api3ServerV1.adminRole(),
+      await api3ServerV1.DAPI_NAME_SETTER_ROLE_DESCRIPTION()
+    );
+  await accessControlRegistry
+    .connect(manager)
+    .grantRole(await api3ServerV1.dapiNameSetterRole(), dapiDataRegistry.address);
+
+  // Initialize special wallet for contract initialization
+  const airseekerInitializationWallet = ethers.Wallet.createRandom().connect(provider);
+  await walletFunder.sendTransaction({
+    to: airseekerInitializationWallet.address,
+    value: ethers.utils.parseEther('1'),
+  });
+
+  // Create templates
+  const pusher1 = loadPusherConfig('pusher-1');
+  const pusher2 = loadPusherConfig('pusher-2');
+  const pusher1Wallet = ethers.Wallet.fromMnemonic(pusher1.nodeSettings.airnodeWalletMnemonic).connect(provider);
+  const pusher2Wallet = ethers.Wallet.fromMnemonic(pusher2.nodeSettings.airnodeWalletMnemonic).connect(provider);
+  const pusher1Beacons = Object.values(pusher1.templates).map((template: any) => {
+    return deriveBeaconData({ ...template, airnodeAddress: pusher1Wallet.address });
+  });
+  const pusher2Beacons = Object.values(pusher2.templates).map((template: any) => {
+    return deriveBeaconData({ ...template, airnodeAddress: pusher2Wallet.address });
+  });
+
+  // Derive beacon set IDs and names
+  const beaconSetIds = zip(pusher1Beacons, pusher2Beacons).map(([beacon1, beacon2]) =>
+    ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [[beacon1!.beaconId, beacon2!.beaconId]]))
+  );
+  const beaconSetNames = pusher1Beacons.map((beacon) => beacon.parameters[0]!.value);
+
+  // Register merkle tree hashes
+  const timestamp = Math.floor(Date.now() / 1000);
+  const apiTreeValues = [
+    [pusher1Wallet.address, `${pusher1.signedApis[0].url}/default`], // NOTE: Pusher pushes to the "/" of the signed API, but we need to query it additional path.
+    [pusher2Wallet.address, `${pusher2.signedApis[0].url}/default`], // NOTE: Pusher pushes to the "/" of the signed API, but we need to query it additional path.
+  ] as const;
+  const apiTree = StandardMerkleTree.of(apiTreeValues as any, ['address', 'string']);
+  const apiHashType = ethers.utils.solidityKeccak256(['string'], ['Signed API URL Merkle tree root']);
+  const rootSigners = [rootSigner1];
+  const apiMessages = ethers.utils.arrayify(
+    ethers.utils.solidityKeccak256(['bytes32', 'bytes32', 'uint256'], [apiHashType, apiTree.root, timestamp])
+  );
+  const apiTreeRootSignatures = await Promise.all(
+    rootSigners.map(async (rootSigner) => rootSigner.signMessage(apiMessages))
+  );
+  await hashRegistry.connect(registryOwner).setupSigners(
+    apiHashType,
+    rootSigners.map((rootSigner) => rootSigner.address)
+  );
+  await hashRegistry.registerHash(apiHashType, apiTree.root, timestamp, apiTreeRootSignatures);
+
+  // Add dAPIs hashes
+  const dapiNamesInfo = zip(beaconSetNames, beaconSetIds).map(
+    ([beaconSetName, beaconSetId]) => [beaconSetName!, beaconSetId!, airseekerInitializationWallet.address] as const
+  );
+  const dapiTreeValues = dapiNamesInfo.map(([dapiName, beaconSetId, sponsorWalletAddress]) => {
+    return [ethers.utils.formatBytes32String(dapiName), beaconSetId, sponsorWalletAddress];
+  });
+  const dapiTree = StandardMerkleTree.of(dapiTreeValues, ['bytes32', 'bytes32', 'address']);
+  const dapiTreeRoot = dapiTree.root;
+  const dapiHashType = ethers.utils.solidityKeccak256(['string'], ['dAPI management Merkle tree root']);
+  const dapiMessages = ethers.utils.arrayify(
+    ethers.utils.solidityKeccak256(['bytes32', 'bytes32', 'uint256'], [dapiHashType, dapiTreeRoot, timestamp])
+  );
+  const dapiTreeRootSignatures = await Promise.all(
+    rootSigners.map(async (rootSigner) => rootSigner.signMessage(dapiMessages))
+  );
+  await hashRegistry.connect(registryOwner).setupSigners(
+    dapiHashType,
+    rootSigners.map((rootSigner) => rootSigner.address)
+  );
+  await hashRegistry.registerHash(dapiHashType, dapiTreeRoot, timestamp, dapiTreeRootSignatures);
+
+  // Set active dAPIs
+  const apiTreeRoot = apiTree.root;
+  for (const [airnode, url] of apiTreeValues) {
+    const apiTreeProof = apiTree.getProof([airnode, url]);
+    await dapiDataRegistry
+      .connect(api3MarketContract)
+      .registerAirnodeSignedApiUrl(airnode, url, apiTreeRoot, apiTreeProof);
+  }
+  const dapiInfos = zip(pusher1Beacons, pusher2Beacons).map(([pusher1Beacon, pusher2Beacon], i) => {
+    return {
+      airnodes: [pusher1Beacon!.airnodeAddress, pusher2Beacon!.airnodeAddress],
+      templateIds: [pusher1Beacon!.templateId, pusher1Beacon!.templateId],
+      dapiTreeValue: dapiTreeValues[i]!,
+    };
+  });
+  for (const dapiInfo of dapiInfos) {
+    const { airnodes, templateIds, dapiTreeValue } = dapiInfo;
+
+    const encodedBeaconSetData = ethers.utils.defaultAbiCoder.encode(
+      ['address[]', 'bytes32[]'],
+      [airnodes, templateIds]
+    );
+    await dapiDataRegistry.connect(randomPerson).registerDataFeed(encodedBeaconSetData);
+    const HUNDRED_PERCENT = 1e8;
+    const deviationThresholdInPercentage = ethers.BigNumber.from(HUNDRED_PERCENT / 1000); // 0.1%
+    const deviationReference = ethers.constants.Zero; // Not used in Airseeker V1
+    const heartbeatInterval = ethers.BigNumber.from(86_400); // 24 hrs
+    const [dapiName, beaconSetId, sponsorWalletMnemonic] = dapiTreeValue;
+    await dapiDataRegistry
+      .connect(api3MarketContract)
+      .addDapi(
+        dapiName!,
+        beaconSetId!,
+        sponsorWalletMnemonic!,
+        deviationThresholdInPercentage,
+        deviationReference,
+        heartbeatInterval,
+        dapiTree.root,
+        dapiTree.getProof(dapiTreeValue)
+      );
+  }
+
+  return {
+    accessControlRegistry,
+    api3ServerV1,
+    dapiDataRegistry,
+
+    pusher1Wallet,
+    pusher2Wallet,
+
+    pusher1Beacons,
+    pusher2Beacons,
+    beaconSetNames,
+  };
+};
+
+async function main() {
+  dotenv.config({ path: `${__dirname}/.env` });
+  if (!process.env.FUNDER_MNEMONIC) throw new Error('FUNDER_MNEMONIC not found');
+  if (!process.env.PROVIDER_URL) throw new Error('PROVIDER_URL not found');
+
+  const provider = new ethers.providers.StaticJsonRpcProvider(process.env.PROVIDER_URL);
+  const funderWallet = ethers.Wallet.fromMnemonic(process.env.FUNDER_MNEMONIC).connect(provider);
+
+  const balance = await funderWallet.getBalance();
+  console.info('Funder balance:', ethers.utils.formatEther(balance.toString()));
+  console.info();
+
+  const { beaconSetNames, api3ServerV1, dapiDataRegistry } = await deploy(funderWallet, provider);
+  console.info('Api3ServerV1 deployed at:', api3ServerV1.address);
+  console.info('DapiDataRegistry deployed at:', dapiDataRegistry.address);
+  console.info();
+
+  await fundAirseekerSponsorWallet(funderWallet, { beaconSetNames });
+}
+
+void main();

--- a/local-test-configuration/signed-api-1/.env.example
+++ b/local-test-configuration/signed-api-1/.env.example
@@ -1,0 +1,16 @@
+LOGGER_ENABLED=true
+LOG_COLORIZE=true
+LOG_FORMAT=pretty
+LOG_LEVEL=debug
+
+# Available options
+#   local (default) - loads config/signed-api.json from the filesystem
+#   aws-s3 - loads the config file from AWS S3
+CONFIG_SOURCE=local
+
+# Set these variables if you would like to source your config from AWS S3
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=
+AWS_S3_BUCKET_NAME=
+AWS_S3_BUCKET_PATH=

--- a/local-test-configuration/signed-api-1/signed-api.json
+++ b/local-test-configuration/signed-api-1/signed-api.json
@@ -1,0 +1,14 @@
+{
+  "endpoints": [
+    {
+      "urlPath": "/default",
+      "delaySeconds": 0
+    }
+  ],
+  "allowedAirnodes": ["0xaC0653E412acAE526Da3a33af0135205A34E21AF"],
+  "maxBatchSize": 10,
+  "port": 8090,
+  "cache": {
+    "maxAgeSeconds": 300
+  }
+}

--- a/local-test-configuration/signed-api-2/.env.example
+++ b/local-test-configuration/signed-api-2/.env.example
@@ -1,0 +1,16 @@
+LOGGER_ENABLED=true
+LOG_COLORIZE=true
+LOG_FORMAT=pretty
+LOG_LEVEL=debug
+
+# Available options
+#   local (default) - loads config/signed-api.json from the filesystem
+#   aws-s3 - loads the config file from AWS S3
+CONFIG_SOURCE=local
+
+# Set these variables if you would like to source your config from AWS S3
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=
+AWS_S3_BUCKET_NAME=
+AWS_S3_BUCKET_PATH=

--- a/local-test-configuration/signed-api-2/signed-api.json
+++ b/local-test-configuration/signed-api-2/signed-api.json
@@ -1,0 +1,14 @@
+{
+  "endpoints": [
+    {
+      "urlPath": "/default",
+      "delaySeconds": 60
+    }
+  ],
+  "allowedAirnodes": ["0x2Bf0dddA8Daa1C3C0Fae9e85866807A1C2D601B7"],
+  "maxBatchSize": 10,
+  "port": 8090,
+  "cache": {
+    "maxAgeSeconds": 300
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,8 @@
     ".eslintrc.js",
     "hardhat.config.ts",
     "jest-e2e.config.js",
-    "jest-unit.config.js"
+    "jest-unit.config.js",
+
+    "./local-test-configuration/**/*"
   ]
 }


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/63

## Rationale

To run Airseeker locally, we need to start multiple services and use correct configurations for each. I wanted to preserve this integration work so I put everything inside a single folder and documented the intentions and steps in a `README.md`. 

There were a few Airseeker issues that needed to be patched. They are in a separate PR https://github.com/api3dao/airseeker-v2/pull/88

At first I though I will just open the PR for discussion and then close it, but I think we might even merge it. The files are **not** included in the build artefacts (because we use a separate tsconfig for that).