### PR TITLE
Fix error handling and update transaction calldata

### DIFF
--- a/src/condition-check/condition-check.ts
+++ b/src/condition-check/condition-check.ts
@@ -48,7 +48,6 @@ export const checkDeviationThresholdExceeded = (
  *
  * Update transaction with stale data would revert on chain, draining the sponsor wallet. See:
  * https://github.com/api3dao/airnode-protocol-v1/blob/dev/contracts/dapis/DataFeedServer.sol#L121
- * This can happen if the gateway or Airseeker is down and Airkeeper does the updates instead.
  */
 export const checkFulfillmentDataTimestamp = (onChainDataTimestamp: number, fulfillmentDataTimestamp: number) =>
   onChainDataTimestamp < fulfillmentDataTimestamp;
@@ -71,7 +70,6 @@ export const checkUpdateConditions = (
   const isFulfillmentDataFresh = checkFulfillmentDataTimestamp(onChainTimestamp, offChainTimestamp);
   if (!isFulfillmentDataFresh) {
     logger.warn(`Off-chain sample's timestamp is older than on-chain timestamp.`);
-
     return false;
   }
 
@@ -82,12 +80,10 @@ export const checkUpdateConditions = (
     const shouldUpdate = checkDeviationThresholdExceeded(onChainValue, deviationThreshold, offChainValue);
     if (shouldUpdate) {
       logger.info(`Deviation exceeded.`);
-
       return true;
     }
   } else {
-    logger.info(`On-chain timestamp is older than the heartbeat interval.`);
-
+    logger.debug(`On-chain timestamp is older than the heartbeat interval.`);
     return true;
   }
 

--- a/src/signed-api-fetch/data-fetcher.ts
+++ b/src/signed-api-fetch/data-fetcher.ts
@@ -105,11 +105,7 @@ export const runDataFetcher = async () => {
               localDataStore.setStoreDataPoint(signedData);
             }
           },
-          {
-            retries: 0,
-            totalTimeoutMs: signedDataFetchIntervalMs,
-            attemptTimeoutMs: signedDataFetchIntervalMs,
-          }
+          { totalTimeoutMs: signedDataFetchIntervalMs }
         )
       )
     );

--- a/src/update-feeds/check-feeds.ts
+++ b/src/update-feeds/check-feeds.ts
@@ -27,7 +27,6 @@ export const getUpdatableFeeds = async (
   const uniqueBeaconIds = [
     ...new Set(batch.flatMap((item) => item.decodedDataFeed.beacons.flatMap((beacon) => beacon.beaconId))),
   ];
-  // TODO: Write a test for this (when multicall throws an error).
   const goOnChainFeedValues = await go(async () => multicallBeaconValues(uniqueBeaconIds, provider, chainId));
   if (!goOnChainFeedValues.success) {
     logger.error(

--- a/src/update-feeds/update-feeds.test.ts
+++ b/src/update-feeds/update-feeds.test.ts
@@ -200,19 +200,10 @@ describe(updateFeedsModule.runUpdateFeeds.name, () => {
       allowPartial<stateModule.State>({
         config: testConfig,
         signedApiUrlStore: {
-          '31337': { 'some-test-provider': { '0xC04575A2773Da9Cd23853A69694e02111b2c4182': 'url-one' } },
+          '31337': {},
         },
         signedApiStore: {},
-        gasPriceStore: {
-          '31337': {
-            'some-test-provider': {
-              gasPrices: [],
-              sponsorLastUpdateTimestampMs: {
-                '0xdatafeedId': 100,
-              },
-            },
-          },
-        },
+        gasPriceStore: {},
       })
     );
     jest
@@ -268,6 +259,50 @@ describe(updateFeedsModule.runUpdateFeeds.name, () => {
       successCount: 0,
     });
   });
+
+  it('catches unhandled error', async () => {
+    const dapi = generateReadDapiWithIndexResponse();
+    const dapiDataRegistry = generateMockDapiDataRegistry();
+    jest
+      .spyOn(dapiDataRegistryModule, 'getDapiDataRegistry')
+      .mockReturnValue(dapiDataRegistry as unknown as DapiDataRegistry);
+    dapiDataRegistry.interface.decodeFunctionResult.mockImplementation((_fn, value) => value);
+    dapiDataRegistry.callStatic.tryMulticall.mockResolvedValueOnce({
+      successes: [true, true],
+      returndata: [[ethers.BigNumber.from(1)], dapi],
+    });
+    const testConfig = generateTestConfig();
+    jest.spyOn(stateModule, 'getState').mockReturnValue(
+      allowPartial<stateModule.State>({
+        config: testConfig,
+        signedApiUrlStore: {},
+        signedApiStore: {},
+        gasPriceStore: {},
+      })
+    );
+    jest.spyOn(logger, 'error');
+    jest.spyOn(checkFeedsModule, 'getUpdatableFeeds').mockRejectedValueOnce(new Error('unexpected-unhandled-error'));
+
+    await updateFeedsModule.runUpdateFeeds(
+      'provider-name',
+      allowPartial<Chain>({
+        dataFeedBatchSize: 1,
+        dataFeedUpdateInterval: 0.1,
+        providers: { ['provider-name']: { url: 'provider-url' } },
+        contracts: {
+          DapiDataRegistry: '0xDD78254f864F97f65e2d86541BdaEf88A504D2B2',
+        },
+      }),
+      '31337'
+    );
+
+    // Expect the logs to be called with the correct context.
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Unexpected error when updating data feeds feeds',
+      new Error('unexpected-unhandled-error')
+    );
+  });
 });
 
 describe(updateFeedsModule.processBatch.name, () => {
@@ -280,9 +315,7 @@ describe(updateFeedsModule.processBatch.name, () => {
     jest.spyOn(stateModule, 'getState').mockReturnValue(
       allowPartial<stateModule.State>({
         config: testConfig,
-        signedApiUrlStore: {
-          '31337': { 'some-test-provider': { '0xC04575A2773Da9Cd23853A69694e02111b2c4182': 'url-one' } },
-        },
+        signedApiUrlStore: {},
         signedApiStore: {
           '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6': {
             airnode: '0xc52EeA00154B4fF1EbbF8Ba39FDe37F1AC3B9Fd4',
@@ -303,16 +336,7 @@ describe(updateFeedsModule.processBatch.name, () => {
             timestamp: (dapi.dataFeedValue.timestamp + 1).toString(),
           },
         },
-        gasPriceStore: {
-          '31337': {
-            'some-test-provider': {
-              gasPrices: [],
-              sponsorLastUpdateTimestampMs: {
-                '0xdatafeedId': 100,
-              },
-            },
-          },
-        },
+        gasPriceStore: {},
       })
     );
     jest.spyOn(logger, 'warn');

--- a/src/update-feeds/update-feeds.test.ts
+++ b/src/update-feeds/update-feeds.test.ts
@@ -317,33 +317,22 @@ describe(updateFeedsModule.processBatch.name, () => {
     );
     jest.spyOn(logger, 'warn');
     jest.spyOn(logger, 'info');
+    jest.spyOn(checkFeedsModule, 'multicallBeaconValues').mockResolvedValue({
+      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6': {
+        timestamp: ethers.BigNumber.from(150),
+        value: ethers.BigNumber.from('400'),
+      },
+      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7': {
+        timestamp: ethers.BigNumber.from(160),
+        value: ethers.BigNumber.from('500'),
+      },
+      '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8': {
+        timestamp: ethers.BigNumber.from(170),
+        value: ethers.BigNumber.from('600'),
+      },
+    });
 
-    const multicallResult = [
-      {
-        beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
-        onChainValue: {
-          timestamp: ethers.BigNumber.from(150),
-          value: ethers.BigNumber.from('400'),
-        },
-      },
-      {
-        beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
-        onChainValue: {
-          timestamp: ethers.BigNumber.from(160),
-          value: ethers.BigNumber.from('500'),
-        },
-      },
-      {
-        beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
-        onChainValue: {
-          timestamp: ethers.BigNumber.from(170),
-          value: ethers.BigNumber.from('600'),
-        },
-      },
-    ];
-    jest.spyOn(checkFeedsModule, 'multicallBeaconValues').mockResolvedValue(multicallResult);
-
-    const feeds = checkFeedsModule.getUpdatableFeeds([decodedDapi], 2, 'hardhat', provider, '31337');
+    const feeds = checkFeedsModule.getUpdatableFeeds([decodedDapi], 2, provider, '31337');
 
     expect(logger.warn).not.toHaveBeenCalledWith(`Off-chain sample's timestamp is older than on-chain timestamp.`);
     expect(logger.warn).not.toHaveBeenCalledWith(`On-chain timestamp is older than the heartbeat interval.`);

--- a/src/update-feeds/update-transactions.test.ts
+++ b/src/update-feeds/update-transactions.test.ts
@@ -2,8 +2,9 @@ import type { Api3ServerV1 } from '@api3/airnode-protocol-v1';
 import { ethers } from 'ethers';
 
 import { generateMockApi3ServerV1 } from '../../test/fixtures/mock-contract';
+import { allowPartial } from '../../test/utils';
 
-import { estimateMulticallGasLimit } from './update-transactions';
+import { type UpdatableDapi, createUpdateFeedCalldatas, estimateMulticallGasLimit } from './update-transactions';
 
 describe(estimateMulticallGasLimit.name, () => {
   it('estimates the gas limit for a multicall', async () => {
@@ -43,5 +44,190 @@ describe(estimateMulticallGasLimit.name, () => {
         undefined
       )
     ).rejects.toStrictEqual(new Error('Unable to estimate gas limit'));
+  });
+});
+
+describe(createUpdateFeedCalldatas.name, () => {
+  it('creates beacon update calldata', () => {
+    const api3ServerV1 = generateMockApi3ServerV1();
+    jest.spyOn(api3ServerV1.interface, 'encodeFunctionData');
+
+    createUpdateFeedCalldatas(
+      api3ServerV1 as unknown as Api3ServerV1,
+      allowPartial<UpdatableDapi>({
+        updatableBeacons: [
+          {
+            beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+            signedData: {
+              airnode: 'airnode',
+              signature: 'some-signature',
+              templateId: 'template',
+              encodedValue: '0x0000000000000000000000000000000000000000000000000000000000000190',
+              timestamp: '200',
+            },
+          },
+        ],
+        dapiInfo: {
+          decodedDataFeed: {
+            beacons: [
+              {
+                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    expect(api3ServerV1.interface.encodeFunctionData).toHaveBeenCalledTimes(1);
+    expect(api3ServerV1.interface.encodeFunctionData).toHaveBeenCalledWith('updateBeaconWithSignedData', [
+      'airnode',
+      'template',
+      '200',
+      '0x0000000000000000000000000000000000000000000000000000000000000190',
+      'some-signature',
+    ]);
+  });
+
+  it('creates beacon set update calldata with all beacons updatable', () => {
+    const api3ServerV1 = generateMockApi3ServerV1();
+    jest.spyOn(api3ServerV1.interface, 'encodeFunctionData');
+
+    createUpdateFeedCalldatas(
+      api3ServerV1 as unknown as Api3ServerV1,
+      allowPartial<UpdatableDapi>({
+        updatableBeacons: [
+          {
+            beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
+            signedData: {
+              airnode: 'airnode-1',
+              signature: 'some-signature-1',
+              templateId: 'template-1',
+              encodedValue: '0x0000000000000000000000000000000000000000000000000000000000000190',
+              timestamp: '200',
+            },
+          },
+          {
+            beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
+            signedData: {
+              airnode: 'airnode-2',
+              signature: 'some-signature-2',
+              templateId: 'template-2',
+              encodedValue: '0x0000000000000000000000000000000000000000000000000000000000000350',
+              timestamp: '300',
+            },
+          },
+          {
+            beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+            signedData: {
+              airnode: 'airnode-3',
+              signature: 'some-signature-3',
+              templateId: 'template-3',
+              encodedValue: '0x0000000000000000000000000000000000000000000000000000000000000270',
+              timestamp: '400',
+            },
+          },
+        ],
+        dapiInfo: {
+          decodedDataFeed: {
+            beacons: [
+              {
+                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
+              },
+              {
+                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
+              },
+              {
+                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    expect(api3ServerV1.interface.encodeFunctionData).toHaveBeenCalledTimes(4);
+    expect(api3ServerV1.interface.encodeFunctionData).toHaveBeenNthCalledWith(1, 'updateBeaconWithSignedData', [
+      'airnode-1',
+      'template-1',
+      '200',
+      '0x0000000000000000000000000000000000000000000000000000000000000190',
+      'some-signature-1',
+    ]);
+    expect(api3ServerV1.interface.encodeFunctionData).toHaveBeenNthCalledWith(2, 'updateBeaconWithSignedData', [
+      'airnode-2',
+      'template-2',
+      '300',
+      '0x0000000000000000000000000000000000000000000000000000000000000350',
+      'some-signature-2',
+    ]);
+    expect(api3ServerV1.interface.encodeFunctionData).toHaveBeenNthCalledWith(3, 'updateBeaconWithSignedData', [
+      'airnode-3',
+      'template-3',
+      '400',
+      '0x0000000000000000000000000000000000000000000000000000000000000270',
+      'some-signature-3',
+    ]);
+    expect(api3ServerV1.interface.encodeFunctionData).toHaveBeenNthCalledWith(4, 'updateBeaconSetWithBeacons', [
+      [
+        '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
+        '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
+        '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+      ],
+    ]);
+  });
+
+  it('updates beacon set update calldata with some beacons updatable', () => {
+    const api3ServerV1 = generateMockApi3ServerV1();
+    jest.spyOn(api3ServerV1.interface, 'encodeFunctionData');
+
+    createUpdateFeedCalldatas(
+      api3ServerV1 as unknown as Api3ServerV1,
+      allowPartial<UpdatableDapi>({
+        updatableBeacons: [
+          {
+            beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+            signedData: {
+              airnode: 'airnode-3',
+              signature: 'some-signature-3',
+              templateId: 'template-3',
+              encodedValue: '0x0000000000000000000000000000000000000000000000000000000000000270',
+              timestamp: '400',
+            },
+          },
+        ],
+        dapiInfo: {
+          decodedDataFeed: {
+            beacons: [
+              {
+                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
+              },
+              {
+                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
+              },
+              {
+                beaconId: '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    expect(api3ServerV1.interface.encodeFunctionData).toHaveBeenCalledTimes(2);
+    expect(api3ServerV1.interface.encodeFunctionData).toHaveBeenNthCalledWith(1, 'updateBeaconWithSignedData', [
+      'airnode-3',
+      'template-3',
+      '400',
+      '0x0000000000000000000000000000000000000000000000000000000000000270',
+      'some-signature-3',
+    ]);
+    expect(api3ServerV1.interface.encodeFunctionData).toHaveBeenNthCalledWith(2, 'updateBeaconSetWithBeacons', [
+      [
+        '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc6',
+        '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc7',
+        '0xf5c140bcb4814dfec311d38f6293e86c02d32ba1b7da027fe5b5202cae35dbc8',
+      ],
+    ]);
   });
 });

--- a/src/update-feeds/update-transactions.ts
+++ b/src/update-feeds/update-transactions.ts
@@ -63,6 +63,8 @@ export const updateFeeds = async (
                 ? [
                     ...beaconUpdateCalls,
                     api3ServerV1.interface.encodeFunctionData('updateBeaconSetWithBeacons', [
+                      // TODO: This needs all beacons in the data feed, not just the updatable ones. Write a test for
+                      // this.
                       updatableBeacons.map(({ beaconId }) => beaconId),
                     ]),
                   ]

--- a/test/e2e/update-feeds.feature.ts
+++ b/test/e2e/update-feeds.feature.ts
@@ -81,10 +81,11 @@ it('updates blockchain data', async () => {
     },
   ]);
 
-  expect(logger.debug).toHaveBeenCalledTimes(5);
-  expect(logger.debug).toHaveBeenNthCalledWith(1, 'Estimating gas limit');
-  expect(logger.debug).toHaveBeenNthCalledWith(2, 'Getting derived sponsor wallet');
-  expect(logger.debug).toHaveBeenNthCalledWith(3, 'Derived new sponsor wallet', expect.anything());
-  expect(logger.debug).toHaveBeenNthCalledWith(4, 'Setting timestamp of the original update transaction');
-  expect(logger.debug).toHaveBeenNthCalledWith(5, 'Updating dAPI', expect.anything());
+  expect(logger.debug).toHaveBeenCalledTimes(6);
+  expect(logger.debug).toHaveBeenNthCalledWith(1, 'Creating calldatas');
+  expect(logger.debug).toHaveBeenNthCalledWith(2, 'Estimating gas limit');
+  expect(logger.debug).toHaveBeenNthCalledWith(3, 'Getting derived sponsor wallet');
+  expect(logger.debug).toHaveBeenNthCalledWith(4, 'Derived new sponsor wallet', expect.anything());
+  expect(logger.debug).toHaveBeenNthCalledWith(5, 'Setting timestamp of the original update transaction');
+  expect(logger.debug).toHaveBeenNthCalledWith(6, 'Updating dAPI', expect.anything());
 });

--- a/test/fixtures/mock-contract.ts
+++ b/test/fixtures/mock-contract.ts
@@ -45,5 +45,8 @@ export const generateMockApi3ServerV1 = () => {
       updateBeaconWithSignedData: jest.fn(),
       updateBeaconSetWithBeacons: jest.fn(),
     },
+    interface: {
+      encodeFunctionData: jest.fn(),
+    },
   } satisfies DeepPartial<Api3ServerV1>;
 };


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/113

## Rationale

I implemented the error handling as the issue says. As I was changing the `multicallBeaconValues` and `getUpdatableFeeds` I decided to simplify it a bit by avoiding mutation in map/filter but I preserved the logic.

I also noticed that we are incorrectly creating the beacon set update calldata. We need to update the beacon set with all beacons (not just the ones that are updatable). I've added a few tests to guard for this.