### PR TITLE
Define Airseeker fields in seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The multiplier used for the provider recommended gas price.
 
 ###### `sanitizationSamplingWindow`
 
-The number of minutes for which to keep historical gas prices.
+The number of seconds for which to keep historical gas prices.
 
 ###### `sanitizationPercentile`
 
@@ -167,7 +167,7 @@ The percentile of gas historical prices to use for sanitization.
 
 ###### `scalingWindow`
 
-The number of minutes used to calculate the scaling multiplier if a pending transaction is detected.
+The number of seconds used to calculate the scaling multiplier if a pending transaction is detected.
 
 ###### `maxScalingMultiplier`
 

--- a/config/airseeker.example.json
+++ b/config/airseeker.example.json
@@ -13,9 +13,9 @@
       },
       "gasSettings": {
         "recommendedGasPriceMultiplier": 1.5,
-        "sanitizationSamplingWindow": 15,
+        "sanitizationSamplingWindow": 900,
         "sanitizationPercentile": 80,
-        "scalingWindow": 2,
+        "scalingWindow": 120,
         "maxScalingMultiplier": 2
       },
       "dataFeedUpdateInterval": 60,

--- a/local-test-configuration/airseeker/airseeker.example.json
+++ b/local-test-configuration/airseeker/airseeker.example.json
@@ -13,9 +13,9 @@
       },
       "gasSettings": {
         "recommendedGasPriceMultiplier": 1.5,
-        "sanitizationSamplingWindow": 15,
+        "sanitizationSamplingWindow": 900,
         "sanitizationPercentile": 80,
-        "scalingWindow": 2,
+        "scalingWindow": 120,
         "maxScalingMultiplier": 2
       },
       "dataFeedUpdateInterval": 30,

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -9,9 +9,9 @@ import { interpolateSecrets } from './utils';
 
 const gasSettings = {
   recommendedGasPriceMultiplier: 1.5,
-  sanitizationSamplingWindow: 15,
+  sanitizationSamplingWindow: 900,
   sanitizationPercentile: 80,
-  scalingWindow: 2,
+  scalingWindow: 120,
   maxScalingMultiplier: 2,
 };
 

--- a/src/gas-price/gas-price.test.ts
+++ b/src/gas-price/gas-price.test.ts
@@ -24,9 +24,9 @@ const provider = new ethers.providers.StaticJsonRpcProvider(rpcUrl, {
 });
 const gasSettings = {
   recommendedGasPriceMultiplier: 1.5,
-  sanitizationSamplingWindow: 15,
+  sanitizationSamplingWindow: 900,
   sanitizationPercentile: 80,
-  scalingWindow: 2,
+  scalingWindow: 120,
   maxScalingMultiplier: 2,
 };
 const timestampMock = 1_696_930_907_351;
@@ -56,7 +56,7 @@ describe(clearExpiredStoreGasPrices.name, () => {
   it('clears expired gas prices from the store', () => {
     const oldGasPriceMock = {
       price: ethers.utils.parseUnits('5', 'gwei'),
-      timestampMs: timestampMock - gasSettings.sanitizationSamplingWindow * 60 * 1000 - 1,
+      timestampMs: timestampMock - gasSettings.sanitizationSamplingWindow * 1000 - 1,
     };
     jest.spyOn(Date, 'now').mockReturnValue(timestampMock);
     jest
@@ -108,7 +108,7 @@ describe(updateGasPriceStore.name, () => {
   it('clears expired gas prices from the store', async () => {
     const oldGasPriceMock = {
       price: ethers.utils.parseUnits('5', 'gwei'),
-      timestampMs: timestampMock - gasSettings.sanitizationSamplingWindow * 60 * 1000 - 1,
+      timestampMs: timestampMock - gasSettings.sanitizationSamplingWindow * 1000 - 1,
     };
     jest.spyOn(Date, 'now').mockReturnValue(timestampMock);
     jest
@@ -175,7 +175,7 @@ describe(getAirseekerRecommendedGasPrice.name, () => {
   it('gets and uses the percentile price from the store', async () => {
     const gasPricesMock = Array.from(Array.from({ length: 10 }), (_, i) => ({
       price: ethers.utils.parseUnits(`${i + 1}`, 'gwei'),
-      timestampMs: timestampMock - 0.9 * gasSettings.sanitizationSamplingWindow * 60 * 1000 - 1,
+      timestampMs: timestampMock - 0.9 * gasSettings.sanitizationSamplingWindow * 1000 - 1,
     }));
     jest.spyOn(Date, 'now').mockReturnValue(timestampMock);
     jest
@@ -235,7 +235,7 @@ describe(getAirseekerRecommendedGasPrice.name, () => {
     const oldGasPriceValueMock = ethers.utils.parseUnits('5', 'gwei');
     const oldGasPriceMock = {
       price: oldGasPriceValueMock,
-      timestampMs: timestampMock - 0.9 * gasSettings.sanitizationSamplingWindow * 60 * 1000 - 1,
+      timestampMs: timestampMock - 0.9 * gasSettings.sanitizationSamplingWindow * 1000 - 1,
     };
     jest.spyOn(Date, 'now').mockReturnValue(timestampMock);
     jest
@@ -274,7 +274,7 @@ describe(getAirseekerRecommendedGasPrice.name, () => {
     updateState((draft) => {
       draft.gasPriceStore[chainId]![providerName]!.gasPrices.unshift(oldGasPriceMock);
       draft.gasPriceStore[chainId]![providerName]!.sponsorLastUpdateTimestampMs[sponsorWalletAddress] =
-        timestampMock - gasSettings.scalingWindow * 60 * 1000 - 1;
+        timestampMock - gasSettings.scalingWindow * 1000 - 1;
     });
     const gasPrice = await getAirseekerRecommendedGasPrice(
       chainId,

--- a/src/gas-price/gas-price.ts
+++ b/src/gas-price/gas-price.ts
@@ -36,7 +36,7 @@ export const clearExpiredStoreGasPrices = (chainId: string, providerName: string
     // Remove gasPrices older than the sanitizationSamplingWindow
     remove(
       draft.gasPriceStore[chainId]![providerName]!.gasPrices,
-      (gasPrice) => gasPrice.timestampMs < Date.now() - sanitizationSamplingWindow * 60 * 1000
+      (gasPrice) => gasPrice.timestampMs < Date.now() - sanitizationSamplingWindow * 1000
     );
   });
 
@@ -168,11 +168,11 @@ export const getAirseekerRecommendedGasPrice = async (
   const lastUpdateTimestampMs = sponsorLastUpdateTimestampMs[sponsorWalletAddress];
 
   // Check if the next update is a retry of a pending transaction and if it has been pending longer than scalingWindow
-  if (lastUpdateTimestampMs && lastUpdateTimestampMs < Date.now() - scalingWindow * 60 * 1000) {
+  if (lastUpdateTimestampMs && lastUpdateTimestampMs < Date.now() - scalingWindow * 1000) {
     const multiplier = calculateScalingMultiplier(
       recommendedGasPriceMultiplier,
       maxScalingMultiplier,
-      (Date.now() - lastUpdateTimestampMs) / (60 * 1000),
+      (Date.now() - lastUpdateTimestampMs) / 1000,
       scalingWindow
     );
 
@@ -181,7 +181,7 @@ export const getAirseekerRecommendedGasPrice = async (
 
   // Check that there are enough entries in the stored gas prices to determine whether to use sanitization or not
   // Calculate the minimum timestamp that should be within the 90% of the sanitizationSamplingWindow
-  const minTimestampMs = Date.now() - 0.9 * sanitizationSamplingWindow * 60 * 1000;
+  const minTimestampMs = Date.now() - 0.9 * sanitizationSamplingWindow * 1000;
 
   // Check if there are entries with a timestamp older than at least 90% of the sanitizationSamplingWindow
   const hasSufficientSanitizationData = gasPrices.some((gasPrice) => gasPrice.timestampMs <= minTimestampMs);

--- a/test/e2e/gas-price.feature.ts
+++ b/test/e2e/gas-price.feature.ts
@@ -11,9 +11,9 @@ const providerName = 'localhost';
 const rpcUrl = 'http://127.0.0.1:8545/';
 const gasSettings = {
   recommendedGasPriceMultiplier: 1.5,
-  sanitizationSamplingWindow: 15,
+  sanitizationSamplingWindow: 900,
   sanitizationPercentile: 80,
-  scalingWindow: 2,
+  scalingWindow: 120,
   maxScalingMultiplier: 2,
 };
 const provider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
@@ -62,7 +62,7 @@ describe(getAirseekerRecommendedGasPrice.name, () => {
   it('clears expired gas prices from the store', async () => {
     const oldGasPriceMock = {
       price: ethers.utils.parseUnits('5', 'gwei'),
-      timestampMs: timestampMock - gasSettings.sanitizationSamplingWindow * 60 * 1000 - 1,
+      timestampMs: timestampMock - gasSettings.sanitizationSamplingWindow * 1000 - 1,
     };
     jest.spyOn(Date, 'now').mockReturnValue(timestampMock);
     await sendTransaction();
@@ -128,7 +128,7 @@ describe(getAirseekerRecommendedGasPrice.name, () => {
     const oldGasPriceValueMock = providerRecommendedGasprice.sub(ethers.utils.parseUnits('1', 'gwei'));
     const oldGasPriceMock = {
       price: oldGasPriceValueMock,
-      timestampMs: timestampMock - 0.9 * gasSettings.sanitizationSamplingWindow * 60 * 1000 - 1,
+      timestampMs: timestampMock - 0.9 * gasSettings.sanitizationSamplingWindow * 1000 - 1,
     };
 
     updateState((draft) => {
@@ -157,7 +157,7 @@ describe(getAirseekerRecommendedGasPrice.name, () => {
 
     updateState((draft) => {
       draft.gasPriceStore[chainId]![providerName]!.sponsorLastUpdateTimestampMs[sponsorWalletAddress] =
-        timestampMock - gasSettings.scalingWindow * 60 * 1000 - 1;
+        timestampMock - gasSettings.scalingWindow * 1000 - 1;
     });
     const gasPrice = await getAirseekerRecommendedGasPrice(
       chainId,

--- a/test/fixtures/mock-config.ts
+++ b/test/fixtures/mock-config.ts
@@ -15,9 +15,9 @@ export const generateTestConfig = (): Config => ({
       gasSettings: {
         recommendedGasPriceMultiplier: 1.5,
         sanitizationPercentile: 80,
-        sanitizationSamplingWindow: 15,
+        sanitizationSamplingWindow: 900,
         maxScalingMultiplier: 2,
-        scalingWindow: 5,
+        scalingWindow: 300,
       },
       dataFeedBatchSize: 10,
       dataFeedUpdateInterval: 60,


### PR DESCRIPTION
Closes https://github.com/api3dao/airseeker-v2/issues/124

## Rationale

I searched for all occurrences of `scalingWindow` and `sanitizationSamplingWindow` and `60` (for conversion from minutes to seconds) and changed them all.