### PR TITLE
Make explicit distinction between dapiName and decodedDapiName

### DIFF
--- a/local-test-configuration/scripts/initialize-chain.ts
+++ b/local-test-configuration/scripts/initialize-chain.ts
@@ -312,9 +312,9 @@ export const deploy = async (funderWallet: ethers.Wallet, provider: ethers.provi
     tx = await dapiDataRegistry
       .connect(api3MarketContract)
       .addDapi(
-        dapiName,
-        beaconSetId,
-        sponsorWalletMnemonic,
+        dapiName!,
+        beaconSetId!,
+        sponsorWalletMnemonic!,
         deviationThresholdInPercentage,
         deviationReference,
         heartbeatInterval,

--- a/local-test-configuration/scripts/initialize-chain.ts
+++ b/local-test-configuration/scripts/initialize-chain.ts
@@ -17,7 +17,7 @@ import {
   DapiDataRegistry__factory as DapiDataRegistryFactory,
   HashRegistry__factory as HashRegistryFactory,
 } from '../../src/typechain-types';
-import { deriveBeaconId, deriveSponsorWallet } from '../../src/utils';
+import { deriveBeaconId, deriveSponsorWallet, encodeDapiName } from '../../src/utils';
 
 interface RawBeaconData {
   airnodeAddress: string;
@@ -59,7 +59,7 @@ export const refundFunder = async (funderWallet: ethers.Wallet) => {
 
   // Initialize sponsor wallets
   for (const beaconSetName of getBeaconSetNames()) {
-    const dapiName = ethers.utils.formatBytes32String(beaconSetName);
+    const dapiName = encodeDapiName(beaconSetName);
 
     const sponsorWallet = deriveSponsorWallet(airseekerWalletMnemonic, dapiName).connect(funderWallet.provider);
     const sponsorWalletBalance = await funderWallet.provider.getBalance(sponsorWallet.address);
@@ -116,7 +116,7 @@ export const fundAirseekerSponsorWallet = async (funderWallet: ethers.Wallet) =>
 
   // Initialize sponsor wallets
   for (const beaconSetName of getBeaconSetNames()) {
-    const dapiName = ethers.utils.formatBytes32String(beaconSetName);
+    const dapiName = encodeDapiName(beaconSetName);
 
     const sponsorWallet = deriveSponsorWallet(airseekerWalletMnemonic, dapiName);
     const sponsorWalletBalance = await funderWallet.provider.getBalance(sponsorWallet.address);
@@ -255,7 +255,7 @@ export const deploy = async (funderWallet: ethers.Wallet, provider: ethers.provi
   const airseekerWalletMnemonic = airseekerSecrets.SPONSOR_WALLET_MNEMONIC;
   if (!airseekerWalletMnemonic) throw new Error('SPONSOR_WALLET_MNEMONIC not found in Airseeker secrets');
   const dapiNamesInfo = zip(beaconSetNames, beaconSetIds).map(([beaconSetName, beaconSetId]) => {
-    const dapiName = ethers.utils.formatBytes32String(beaconSetName!);
+    const dapiName = encodeDapiName(beaconSetName!);
     const sponsorWallet = deriveSponsorWallet(airseekerWalletMnemonic, dapiName);
     return [dapiName, beaconSetId!, sponsorWallet.address] as const;
   });
@@ -312,9 +312,9 @@ export const deploy = async (funderWallet: ethers.Wallet, provider: ethers.provi
     tx = await dapiDataRegistry
       .connect(api3MarketContract)
       .addDapi(
-        dapiName!,
-        beaconSetId!,
-        sponsorWalletMnemonic!,
+        dapiName,
+        beaconSetId,
+        sponsorWalletMnemonic,
         deviationThresholdInPercentage,
         deviationReference,
         heartbeatInterval,

--- a/src/update-feeds/check-feeds.test.ts
+++ b/src/update-feeds/check-feeds.test.ts
@@ -6,6 +6,7 @@ import { logger } from '../logger';
 import * as signedDataStore from '../signed-data-store/signed-data-store';
 import { updateState } from '../state';
 import type { BeaconId, SignedData } from '../types';
+import { encodeDapiName } from '../utils';
 
 import * as contractUtils from './api3-server-v1';
 import { multicallBeaconValues, getUpdatableFeeds } from './check-feeds';
@@ -145,7 +146,7 @@ describe(getUpdatableFeeds.name, () => {
           dataFeedId: '0x000',
           beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
         },
-        dapiName: 'test',
+        dapiName: encodeDapiName('test'),
       },
     ]);
 
@@ -164,7 +165,7 @@ describe(getUpdatableFeeds.name, () => {
           }),
         ],
         dapiInfo: {
-          dapiName: 'test',
+          dapiName: encodeDapiName('test'),
           dataFeedValue: {
             timestamp: 95,
             value: ethers.BigNumber.from('10'),
@@ -242,7 +243,7 @@ describe(getUpdatableFeeds.name, () => {
           dataFeedId: '0x000',
           beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
         },
-        dapiName: 'test',
+        dapiName: encodeDapiName('test'),
       },
     ]);
 
@@ -261,7 +262,7 @@ describe(getUpdatableFeeds.name, () => {
           }),
         ],
         dapiInfo: {
-          dapiName: 'test',
+          dapiName: encodeDapiName('test'),
           dataFeedValue: {
             timestamp: 90,
             value: ethers.BigNumber.from('400'),
@@ -323,7 +324,7 @@ describe(getUpdatableFeeds.name, () => {
           dataFeedId: '0x000',
           beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
         },
-        dapiName: 'test',
+        dapiName: encodeDapiName('test'),
       },
     ]);
 
@@ -400,7 +401,7 @@ describe(getUpdatableFeeds.name, () => {
           dataFeedId: '0x000',
           beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
         },
-        dapiName: 'test',
+        dapiName: encodeDapiName('test'),
       },
     ]);
 
@@ -423,7 +424,8 @@ describe(getUpdatableFeeds.name, () => {
           dataFeedId: '0x000',
           beacons: [{ beaconId: feedIds[0] }, { beaconId: feedIds[1] }, { beaconId: feedIds[2] }],
         },
-        dapiName: 'test',
+        dapiName: encodeDapiName('test'),
+        decodedDapiName: 'test',
       },
     ]);
     jest.spyOn(checkFeedsModule, 'multicallBeaconValues').mockRejectedValueOnce(new Error('Multicall failed'));

--- a/src/update-feeds/check-feeds.ts
+++ b/src/update-feeds/check-feeds.ts
@@ -32,7 +32,7 @@ export const getUpdatableFeeds = async (
     logger.error(
       `Multicalling on-chain data feed values has failed. Skipping update for all dAPIs in a batch`,
       goOnChainFeedValues.error,
-      { dapiNames: batch.map((dapi) => dapi.dapiName) }
+      { dapiNames: batch.map((dapi) => dapi.decodedDapiName) }
     );
     return [];
   }

--- a/src/update-feeds/dapi-data-registry.ts
+++ b/src/update-feeds/dapi-data-registry.ts
@@ -3,7 +3,7 @@ import { ethers } from 'ethers';
 // NOTE: The contract is not yet published, so we generate the Typechain artifacts locally and import it from there.
 import { type DapiDataRegistry, DapiDataRegistry__factory as DapiDataRegistryFactory } from '../typechain-types';
 import type { DecodedDataFeed } from '../types';
-import { deriveBeaconId, deriveBeaconSetId } from '../utils';
+import { decodeDapiName, deriveBeaconId, deriveBeaconSetId } from '../utils';
 
 export const getDapiDataRegistry = (address: string, provider: ethers.providers.StaticJsonRpcProvider) =>
   DapiDataRegistryFactory.connect(address, provider);
@@ -67,8 +67,8 @@ export const decodeReadDapiWithIndexResponse = (
   const decodedDataFeed = decodeDataFeed(dataFeed);
 
   return {
-    dapiName,
-    // TODO: Add decoded dapiName to make it clear which one is encoded and which one is decoded
+    dapiName, // NOTE: Anywhere in the codebase the "dapiName" is the encoded version of the dAPI name.
+    decodedDapiName: decodeDapiName(dapiName),
     updateParameters: {
       deviationReference,
       deviationThresholdInPercentage,

--- a/src/update-feeds/update-feeds.test.ts
+++ b/src/update-feeds/update-feeds.test.ts
@@ -321,7 +321,11 @@ describe(updateFeedsModule.processBatch.name, () => {
   it('applies deviationThresholdCoefficient from config', async () => {
     const dapi = generateReadDapiWithIndexResponse();
     const decodedDataFeed = dapiDataRegistryModule.decodeDataFeed(dapi.dataFeed);
-    const decodedDapi = { ...omit(dapi, ['dataFeed']), decodedDataFeed };
+    const decodedDapi = {
+      ...omit(dapi, ['dataFeed']),
+      decodedDataFeed,
+      decodedDapiName: utilsModule.decodeDapiName(dapi.dapiName),
+    };
     jest.spyOn(Date, 'now').mockReturnValue(dapi.dataFeedValue.timestamp);
     const testConfig = generateTestConfig();
     jest.spyOn(stateModule, 'getState').mockReturnValue(

--- a/src/update-feeds/update-feeds.ts
+++ b/src/update-feeds/update-feeds.ts
@@ -221,7 +221,7 @@ export const processBatch = async (
   provider: ethers.providers.StaticJsonRpcProvider,
   chainId: ChainId
 ) => {
-  logger.debug('Processing batch of active dAPIs', { dapiNames: batch.map((dapi) => dapi.dapiName) });
+  logger.debug('Processing batch of active dAPIs', { dapiNames: batch.map((dapi) => dapi.decodedDapiName) });
   const {
     config: { sponsorWalletMnemonic, chains, deviationThresholdCoefficient },
   } = getState();
@@ -247,7 +247,7 @@ export const processBatch = async (
 
   // Clear last update timestamps for feeds that don't need an update
   for (const feed of batch) {
-    const { dapiName } = feed;
+    const { dapiName, decodedDapiName } = feed;
 
     if (!dapiNamesToUpdate.has(dapiName)) {
       const sponsorWalletAddress = deriveSponsorWallet(sponsorWalletMnemonic, dapiName).address;
@@ -260,7 +260,7 @@ export const processBatch = async (
         // We can't differentiate between these cases unless we check recent update transactions, which we don't want to
         // do.
         logger.debug(`Clearing dAPI update timestamp because it no longer needs an update`, {
-          dapiName,
+          dapiName: decodedDapiName,
         });
         clearSponsorLastUpdateTimestampMs(chainId, providerName, sponsorWalletAddress);
       }

--- a/src/update-feeds/update-transactions.test.ts
+++ b/src/update-feeds/update-transactions.test.ts
@@ -237,7 +237,7 @@ describe(updateTransactionsModule.createUpdateFeedCalldatas.name, () => {
 });
 
 describe(updateTransactionsModule.getDerivedSponsorWallet.name, () => {
-  const dapiName = ethers.utils.formatBytes32String('ETH/USD');
+  const dapiName = utilsModule.encodeDapiName('ETH/USD');
 
   it('returns the derived sponsor wallet', () => {
     jest.spyOn(stateModule, 'getState').mockReturnValue(
@@ -284,8 +284,12 @@ describe(updateTransactionsModule.updateFeeds.name, () => {
       new ethers.providers.StaticJsonRpcProvider(),
       generateMockApi3ServerV1() as unknown as Api3ServerV1,
       [
-        allowPartial<updateTransactionsModule.UpdatableDapi>({ dapiInfo: { dapiName: 'ETH/USD' } }),
-        allowPartial<updateTransactionsModule.UpdatableDapi>({ dapiInfo: { dapiName: 'BTC/USD' } }),
+        allowPartial<updateTransactionsModule.UpdatableDapi>({
+          dapiInfo: { dapiName: utilsModule.encodeDapiName('ETH/USD') },
+        }),
+        allowPartial<updateTransactionsModule.UpdatableDapi>({
+          dapiInfo: { dapiName: utilsModule.encodeDapiName('BTC/USD') },
+        }),
       ]
     );
 
@@ -294,7 +298,7 @@ describe(updateTransactionsModule.updateFeeds.name, () => {
 });
 
 describe(updateTransactionsModule.updateFeed.name, () => {
-  const dapiName = ethers.utils.formatBytes32String('ETH/USD');
+  const dapiName = utilsModule.encodeDapiName('ETH/USD');
 
   it('updates a dapi', async () => {
     jest.spyOn(updateTransactionsModule, 'createUpdateFeedCalldatas').mockReturnValue(['calldata1', 'calldata2']);

--- a/src/update-feeds/update-transactions.ts
+++ b/src/update-feeds/update-transactions.ts
@@ -61,12 +61,13 @@ export const updateFeed = async (
   const { dapiInfo } = updatableDapi;
   const {
     dapiName,
+    decodedDapiName,
     decodedDataFeed: { dataFeedId },
   } = dapiInfo;
   const { dataFeedUpdateInterval, fallbackGasLimit } = chains[chainId]!;
   const dataFeedUpdateIntervalMs = dataFeedUpdateInterval * 1000;
 
-  return logger.runWithContext({ dapiName, dataFeedId }, async () => {
+  return logger.runWithContext({ dapiName: decodedDapiName, dataFeedId }, async () => {
     // NOTE: We use go mainly to set a timeout for the whole update process. We expect the function not to throw and
     // handle errors internally.
     const goUpdate = await go(

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,10 +1,8 @@
-import { ethers } from 'ethers';
-
-import { deriveSponsorWallet, deriveWalletPathFromSponsorAddress } from './utils';
+import { deriveSponsorWallet, deriveWalletPathFromSponsorAddress, encodeDapiName } from './utils';
 
 describe(deriveSponsorWallet.name, () => {
   it('derives sponsor wallets for a dAPI', () => {
-    const btcEthDapiName = ethers.utils.formatBytes32String('BTC/ETH');
+    const btcEthDapiName = encodeDapiName('BTC/ETH');
     const sponsorWalletMnemonic = 'diamond result history offer forest diagram crop armed stumble orchard stage glance';
 
     const btcEthSponsorWallet = deriveSponsorWallet(sponsorWalletMnemonic, btcEthDapiName);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,10 @@ export function deriveBeaconSetId(beaconIds: string[]) {
   return goSync(() => ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [beaconIds]))).data;
 }
 
+export const encodeDapiName = (dapiName: string) => ethers.utils.formatBytes32String(dapiName);
+
+export const decodeDapiName = (dapiName: string) => ethers.utils.parseBytes32String(dapiName);
+
 export function deriveWalletPathFromSponsorAddress(sponsorAddress: string) {
   const sponsorAddressBN = ethers.BigNumber.from(sponsorAddress);
   const paths = [];

--- a/test/e2e/update-feeds.feature.ts
+++ b/test/e2e/update-feeds.feature.ts
@@ -7,6 +7,7 @@ import * as stateModule from '../../src/state';
 import { runUpdateFeeds } from '../../src/update-feeds';
 import { decodeDataFeed } from '../../src/update-feeds/dapi-data-registry';
 import { updateFeeds } from '../../src/update-feeds/update-transactions';
+import { decodeDapiName } from '../../src/utils';
 import { initializeState } from '../fixtures/mock-config';
 import { deployAndUpdate } from '../setup/contract';
 import { generateSignedData } from '../utils';
@@ -49,7 +50,11 @@ it('updates blockchain data', async () => {
   const btcDapi = await dapiDataRegistry.readDapiWithIndex(0);
 
   const decodedDataFeed = decodeDataFeed(btcDapi.dataFeed);
-  const decodedBtcDapi = { ...omit(btcDapi, ['dataFeed']), decodedDataFeed };
+  const decodedBtcDapi = {
+    ...omit(btcDapi, ['dataFeed']),
+    decodedDataFeed,
+    decodedDapiName: decodeDapiName(btcDapi.dapiName),
+  };
 
   const currentBlock = await dapiDataRegistry.provider.getBlock('latest');
   const currentBlockTimestamp = currentBlock.timestamp;

--- a/test/fixtures/mock-contract.ts
+++ b/test/fixtures/mock-contract.ts
@@ -2,10 +2,11 @@ import type { Api3ServerV1 } from '@api3/airnode-protocol-v1';
 import { ethers } from 'ethers';
 
 import type { DapiDataRegistry } from '../../src/typechain-types';
+import { encodeDapiName } from '../../src/utils';
 import { type DeepPartial, encodeBeaconFeed } from '../utils';
 
 export const generateReadDapiWithIndexResponse = () => ({
-  dapiName: ethers.utils.formatBytes32String('MOCK_FEED'),
+  dapiName: encodeDapiName('MOCK_FEED'),
   updateParameters: {
     deviationThresholdInPercentage: ethers.BigNumber.from(0.5 * 1e8),
     deviationReference: ethers.BigNumber.from(0.5 * 1e8),

--- a/test/setup/contract.ts
+++ b/test/setup/contract.ts
@@ -13,7 +13,7 @@ import {
   DapiDataRegistry__factory as DapiDataRegistryFactory,
   HashRegistry__factory as HashRegistryFactory,
 } from '../../src/typechain-types';
-import { deriveBeaconId, deriveSponsorWallet } from '../../src/utils';
+import { deriveBeaconId, deriveSponsorWallet, encodeDapiName } from '../../src/utils';
 import { generateTestConfig } from '../fixtures/mock-config';
 import { signData } from '../utils';
 
@@ -283,8 +283,8 @@ export const deployAndUpdate = async () => {
     ['BTC/USD', btcBeaconSetId, airseekerInitializationWallet.address],
     ['ETH/USD', ethBeaconSetId, airseekerInitializationWallet.address],
   ] as const;
-  const dapiTreeValues = dapiNamesInfo.map(([dapiName, beaconSetId, sponsorWalletAddress]) => {
-    return [ethers.utils.formatBytes32String(dapiName), beaconSetId, sponsorWalletAddress];
+  const dapiTreeValues = dapiNamesInfo.map(([decodedDapiName, beaconSetId, sponsorWalletAddress]) => {
+    return [encodeDapiName(decodedDapiName), beaconSetId, sponsorWalletAddress];
   });
   const dapiTree = StandardMerkleTree.of(dapiTreeValues, ['bytes32', 'bytes32', 'address']);
   const dapiTreeRoot = dapiTree.root;


### PR DESCRIPTION
## Rationale

As I was doing updates in the codebase I got a bit lost in whether the `dapiName` is the encoded or decoded version. We were mixing that in tests (because it often didn't matter) and were using it also in logs (but we should always use the decode dAPI name for convenience).

I made the distinction by introducing `decodedDapiName` and introducing a convention that `dapiName` is the encoded version. I've updated the tests and logs to reflect this. 